### PR TITLE
Bug fix BaseRequest / MemberRequest

### DIFF
--- a/MailChimp.Net/Core/Requests/MemberRequest.cs
+++ b/MailChimp.Net/Core/Requests/MemberRequest.cs
@@ -3,6 +3,9 @@
 //   N/A
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
+
+using MailChimp.Net.Models;
+
 namespace MailChimp.Net.Core
 {
     /// <summary>
@@ -14,7 +17,7 @@ namespace MailChimp.Net.Core
         public string EmailType { get; set; }
 
         [QueryString("status")]
-        public bool Status { get; set; }
+        public Status? Status { get; set; }
 
         [QueryString("since_timestamp_opt")]
         public string SinceTimestamp { get; set; }

--- a/MailChimp.Net/Interfaces/IMemberLogic.cs
+++ b/MailChimp.Net/Interfaces/IMemberLogic.cs
@@ -57,6 +57,14 @@ namespace MailChimp.Net.Interfaces
         Task<IEnumerable<Member>> GetAllAsync(string listId, MemberRequest memberRequest = null);
 
         /// <summary>
+        /// Get the total number of members in the list
+        /// </summary>
+        /// <param name="listId"></param>
+        /// <param name="status"></param>
+        /// <returns></returns>
+        Task<int> GetTotalItems(string listId, Status? status);
+
+        /// <summary>
         /// The get async.
         /// </summary>
         /// <param name="listId">

--- a/MailChimp.Net/Logic/MemberLogic.cs
+++ b/MailChimp.Net/Logic/MemberLogic.cs
@@ -207,6 +207,27 @@ namespace MailChimp.Net.Logic
             }
         }
 
+
+        /// <summary>
+        /// Get the total number of members in the list
+        /// </summary>
+        /// <param name="listId"></param>
+        /// <param name="status"></param>
+        /// <returns></returns>
+        public async Task<int> GetTotalItems(string listId, Status? status)
+        {
+            using (var client = this.CreateMailClient("lists/"))
+            {
+                var memberRequest = new MemberRequest { Status = status, FieldsToInclude = "total_items" };
+
+                var response = await client.GetAsync($"{listId}/members{memberRequest.ToQueryString()}").ConfigureAwait(false);
+                await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
+
+                var listResponse = await response.Content.ReadAsAsync<MemberResponse>().ConfigureAwait(false);
+                return listResponse.TotalItems;
+            }
+        }
+
         /// <summary>
         /// The get async.
         /// </summary>


### PR DESCRIPTION
Changed Status attribute type from bool to Status enum in MemberRequest
to match the requirements of MailChimp API.

Fixed a bug in BaseRequest where Nullable enum attributes were not
appended to the query string