### PR TITLE
Updated Member Notes to LastNote

### DIFF
--- a/MailChimp.Net/Interfaces/IMailChimpManager.cs
+++ b/MailChimp.Net/Interfaces/IMailChimpManager.cs
@@ -44,5 +44,10 @@ namespace MailChimp.Net.Interfaces
         /// Gets the members.
         /// </summary>
         IMemberLogic Members { get; }
+
+        /// <summary>
+        /// Gets the members.
+        /// </summary>
+        INoteLogic Notes { get; }
     }
 }

--- a/MailChimp.Net/Logic/MemberLogic.cs
+++ b/MailChimp.Net/Logic/MemberLogic.cs
@@ -315,7 +315,6 @@ namespace MailChimp.Net.Logic
             {
                 var response = await client.GetAsync($"{listId}/members/{this.Hash(emailAddress.ToLower())}{request?.ToQueryString()}").ConfigureAwait(false);
                 await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
-
                 return await response.Content.ReadAsAsync<Member>().ConfigureAwait(false);
             }
         }

--- a/MailChimp.Net/Logic/NoteLogic.cs
+++ b/MailChimp.Net/Logic/NoteLogic.cs
@@ -129,7 +129,7 @@ namespace MailChimp.Net.Logic
             string emailAddress,
             QueryableBaseRequest request = null)
         {
-            using (var client = this.CreateMailClient("lists"))
+            using (var client = this.CreateMailClient("lists/"))
             {
                 var response =
                     await
@@ -162,7 +162,7 @@ namespace MailChimp.Net.Logic
             string emailAddress,
             QueryableBaseRequest request = null)
         {
-            using (var client = this.CreateMailClient("lists"))
+            using (var client = this.CreateMailClient("lists/"))
             {
                 var response =
                     await

--- a/MailChimp.Net/Models/Member.cs
+++ b/MailChimp.Net/Models/Member.cs
@@ -112,10 +112,10 @@ namespace MailChimp.Net.Models
         public Dictionary<string, string> MergeFields { get; set; }
 
         /// <summary>
-        /// Gets or sets the notes.
+        /// Gets or sets the last Note.
         /// </summary>
         [JsonProperty("last_note")]
-        public IEnumerable<object> Notes { get; set; }
+        public MemberLastNote LastNote { get; set; }
 
         /// <summary>
         /// Gets or sets the stats.

--- a/MailChimp.Net/Models/Note.cs
+++ b/MailChimp.Net/Models/Note.cs
@@ -61,4 +61,32 @@ namespace MailChimp.Net.Models
         [JsonProperty("updated_at")]
         public string UpdatedAt { get; set; }
     }
+
+    public class MemberLastNote
+    {
+        /// <summary>
+        /// Gets or sets the id.
+        /// </summary>
+        [JsonProperty("note_id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the body.
+        /// </summary>
+        [JsonProperty("note")]
+        public string Body { get; set; }
+
+        /// <summary>
+        /// Gets or sets the created at.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public string CreatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the created by.
+        /// </summary>
+        [JsonProperty("created_by")]
+        public string CreatedBy { get; set; }
+
+    }
 }


### PR DESCRIPTION
A member had no such thing as "Notes" in its reply, only a "last_note",
of following format:
"last_note":{ "note_id":281, "created_at":"2016-04-15T07:10:07+00:00",
"created_by":"58898545", "note":"test123" }
So Deserializing failed if member had a note on the MailChimp site..

Also, I changed 
-            using (var client = this.CreateMailClient("lists"))
+            using (var client = this.CreateMailClient("lists/"))
I didn't have time to check if this was needed anywhere else, but if there are any other trailing slashes missing, errors may occur.. Didn't have time to check, sorry :-)