### PR TITLE
Fixed issue with adding new ListSegment through the API

### DIFF
--- a/MailChimp.Net/Core/Requests/Segment.cs
+++ b/MailChimp.Net/Core/Requests/Segment.cs
@@ -11,6 +11,6 @@ namespace MailChimp.Net.Core
         [JsonProperty("static_segment")]
         public IEnumerable<string> EmailAddresses { get; set; }
         [JsonProperty("options")]
-        public IEnumerable<SegmentOptions> Options { get; set; }
+        public SegmentOptions Options { get; set; }
     }
 }

--- a/MailChimp.Net/Models/Condition.cs
+++ b/MailChimp.Net/Models/Condition.cs
@@ -32,6 +32,6 @@ namespace MailChimp.Net.Models
         /// Gets or sets the value.
         /// </summary>
         [JsonProperty("value")]
-        public int Value { get; set; }
+        public string Value { get; set; }
     }
 }

--- a/MailChimp.Net/Models/ListSegment.cs
+++ b/MailChimp.Net/Models/ListSegment.cs
@@ -11,7 +11,6 @@ namespace MailChimp.Net.Models
     {
         public ListSegment()
         {
-            Options = new HashSet<SegmentOptions>();
             Links = new HashSet<Link>();
         }
 
@@ -40,6 +39,6 @@ namespace MailChimp.Net.Models
         public IEnumerable<Link> Links { get; set; }
 
         [JsonProperty("options")]
-        public IEnumerable<SegmentOptions> Options { get; set; }
+        public SegmentOptions Options { get; set; }
     }
 }


### PR DESCRIPTION
Unable to create a ListSegment with a condition like "FNAME is Casper" because the value-property was of type int. Change to string