### PR TITLE
Final Fixes - Prevent EmailsSent being sent through on a patch reques…

### DIFF
--- a/MailChimp.Net/Core/HttpRequestExtensions.cs
+++ b/MailChimp.Net/Core/HttpRequestExtensions.cs
@@ -82,7 +82,7 @@ namespace MailChimp.Net.Core
                                   RequestUri = new Uri(client.BaseAddress + requestUri), 
                                   Content = content
                               };
-
+			client.DefaultRequestHeaders.ExpectContinue = false;
             return await client.SendAsync(request);
         }
 

--- a/MailChimp.Net/Interfaces/ICampaignLogic.cs
+++ b/MailChimp.Net/Interfaces/ICampaignLogic.cs
@@ -33,28 +33,30 @@ namespace MailChimp.Net.Interfaces
         [Obsolete]
         Task<Campaign> AddOrUpdateAsync(string campaignId, Campaign campaign);
 
-        /// <summary>
-        /// The add or update async.
-        /// </summary>
-        /// <param name="campaign">
-        /// The campaign.
-        /// </param>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
-        Task<Campaign> AddOrUpdateAsync(Campaign campaign);
+		/// <summary>
+		/// The add or update async.
+		/// </summary>
+		/// <param name="campaign">
+		/// The campaign.
+		/// </param>
+		/// <returns>
+		/// The <see cref="Task"/>.
+		/// </returns>
+		Task<Campaign> AddOrUpdateAsync(Campaign campaign);
+		Task<Campaign> AddAsync(Campaign campaign);
+		Task<Campaign> UpdateAsync(string campaignId, Campaign campaign);
 
 
-        /// <summary>
-        /// The cancel async.
-        /// </summary>
-        /// <param name="campaignId">
-        /// The campaign id.
-        /// </param>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
-        Task CancelAsync(string campaignId);
+		/// <summary>
+		/// The cancel async.
+		/// </summary>
+		/// <param name="campaignId">
+		/// The campaign id.
+		/// </param>
+		/// <returns>
+		/// The <see cref="Task"/>.
+		/// </returns>
+		Task CancelAsync(string campaignId);
 
         /// <summary>
         /// The delete async.

--- a/MailChimp.Net/Logic/CampaignLogic.cs
+++ b/MailChimp.Net/Logic/CampaignLogic.cs
@@ -33,63 +33,77 @@ namespace MailChimp.Net.Logic
         {
         }
 
-        /// <summary>
-        /// The add or update async.
-        /// </summary>
-        /// <param name="campaignId">
-        /// The campaign id.
-        /// </param>
-        /// <param name="campaign">
-        /// The campaign.
-        /// </param>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref>
-        ///         <name>uriString</name>
-        ///     </paramref>
-        ///     is null. </exception>
-        /// <exception cref="MailChimpException">
-        /// Custom Mail Chimp Exception
-        /// </exception>
-        /// <exception cref="UriFormatException">In the .NET for Windows Store apps or the Portable Class Library, catch the base class exception, <see cref="T:System.FormatException" />, instead.<paramref name="uriString" /> is empty.-or- The scheme specified in <paramref name="uriString" /> is not correctly formed. See <see cref="M:System.Uri.CheckSchemeName(System.String)" />.-or- <paramref name="uriString" /> contains too many slashes.-or- The password specified in <paramref name="uriString" /> is not valid.-or- The host name specified in <paramref name="uriString" /> is not valid.-or- The file name specified in <paramref name="uriString" /> is not valid. -or- The user name specified in <paramref name="uriString" /> is not valid.-or- The host or authority name specified in <paramref name="uriString" /> cannot be terminated by backslashes.-or- The port number specified in <paramref name="uriString" /> is not valid or cannot be parsed.-or- The length of <paramref name="uriString" /> exceeds 65519 characters.-or- The length of the scheme specified in <paramref name="uriString" /> exceeds 1023 characters.-or- There is an invalid character sequence in <paramref name="uriString" />.-or- The MS-DOS path specified in <paramref name="uriString" /> must start with c:\\.</exception>
-        public async Task<Campaign> AddOrUpdateAsync(Campaign campaign)
-        {
-            if (string.IsNullOrWhiteSpace(campaign.Id))
-            {
-                return await this.CreateAsync(campaign).ConfigureAwait(false);
-            }
+		/// <summary>
+		/// The add or update async.
+		/// </summary>
+		/// <param name="campaignId">
+		/// The campaign id.
+		/// </param>
+		/// <param name="campaign">
+		/// The campaign.
+		/// </param>
+		/// <returns>
+		/// The <see cref="Task"/>.
+		/// </returns>
+		/// <exception cref="ArgumentNullException"><paramref>
+		///         <name>uriString</name>
+		///     </paramref>
+		///     is null. </exception>
+		/// <exception cref="MailChimpException">
+		/// Custom Mail Chimp Exception
+		/// </exception>
+		/// <exception cref="UriFormatException">In the .NET for Windows Store apps or the Portable Class Library, catch the base class exception, <see cref="T:System.FormatException" />, instead.<paramref name="uriString" /> is empty.-or- The scheme specified in <paramref name="uriString" /> is not correctly formed. See <see cref="M:System.Uri.CheckSchemeName(System.String)" />.-or- <paramref name="uriString" /> contains too many slashes.-or- The password specified in <paramref name="uriString" /> is not valid.-or- The host name specified in <paramref name="uriString" /> is not valid.-or- The file name specified in <paramref name="uriString" /> is not valid. -or- The user name specified in <paramref name="uriString" /> is not valid.-or- The host or authority name specified in <paramref name="uriString" /> cannot be terminated by backslashes.-or- The port number specified in <paramref name="uriString" /> is not valid or cannot be parsed.-or- The length of <paramref name="uriString" /> exceeds 65519 characters.-or- The length of the scheme specified in <paramref name="uriString" /> exceeds 1023 characters.-or- There is an invalid character sequence in <paramref name="uriString" />.-or- The MS-DOS path specified in <paramref name="uriString" /> must start with c:\\.</exception>
+		public async Task<Campaign> AddOrUpdateAsync(Campaign campaign)
+		{
+			if (string.IsNullOrWhiteSpace(campaign.Id))
+			{
+				return await this.CreateAsync(campaign).ConfigureAwait(false);
+			}
 
-            using (var client = this.CreateMailClient("campaigns/"))
-            {
-                var response = await client.PatchAsJsonAsync($"{campaign.Id}", campaign).ConfigureAwait(false);
-                await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
+			using (var client = this.CreateMailClient("campaigns/"))
+			{
+				var response = await client.PatchAsJsonAsync($"{campaign.Id}", campaign).ConfigureAwait(false);
+				await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
 
-                return await response.Content.ReadAsAsync<Campaign>().ConfigureAwait(false);
-            }
-        }
+				return await response.Content.ReadAsAsync<Campaign>().ConfigureAwait(false);
+			}
+		}
+		public async Task<Campaign> AddAsync(Campaign campaign)
+		{
+			return await this.CreateAsync(campaign).ConfigureAwait(false);
+		}
+		public async Task<Campaign> UpdateAsync(string campaignId, Campaign campaign)
+		{
+			using (var client = this.CreateMailClient("campaigns/"))
+			{
+				var response = await client.PatchAsJsonAsync($"{campaignId}", campaign).ConfigureAwait(false);
+				await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
 
-        /// <summary>
-        /// The add or update async.
-        /// </summary>
-        /// <param name="campaignId">
-        /// The campaign id.
-        /// </param>
-        /// <param name="campaign">
-        /// The campaign.
-        /// </param>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref>
-        ///         <name>uriString</name>
-        ///     </paramref>
-        ///     is null. </exception>
-        /// <exception cref="UriFormatException">In the .NET for Windows Store apps or the Portable Class Library, catch the base class exception, <see cref="T:System.FormatException" />, instead.<paramref name="uriString" /> is empty.-or- The scheme specified in <paramref name="uriString" /> is not correctly formed. See <see cref="M:System.Uri.CheckSchemeName(System.String)" />.-or- <paramref name="uriString" /> contains too many slashes.-or- The password specified in <paramref name="uriString" /> is not valid.-or- The host name specified in <paramref name="uriString" /> is not valid.-or- The file name specified in <paramref name="uriString" /> is not valid. -or- The user name specified in <paramref name="uriString" /> is not valid.-or- The host or authority name specified in <paramref name="uriString" /> cannot be terminated by backslashes.-or- The port number specified in <paramref name="uriString" /> is not valid or cannot be parsed.-or- The length of <paramref name="uriString" /> exceeds 65519 characters.-or- The length of the scheme specified in <paramref name="uriString" /> exceeds 1023 characters.-or- There is an invalid character sequence in <paramref name="uriString" />.-or- The MS-DOS path specified in <paramref name="uriString" /> must start with c:\\.</exception>
-        /// <exception cref="MailChimpException">
-        /// Custom Mail Chimp Exception
-        /// </exception>
-        [Obsolete]
+				return await response.Content.ReadAsAsync<Campaign>().ConfigureAwait(false);
+			}
+		}
+
+		/// <summary>
+		/// The add or update async.
+		/// </summary>
+		/// <param name="campaignId">
+		/// The campaign id.
+		/// </param>
+		/// <param name="campaign">
+		/// The campaign.
+		/// </param>
+		/// <returns>
+		/// The <see cref="Task"/>.
+		/// </returns>
+		/// <exception cref="ArgumentNullException"><paramref>
+		///         <name>uriString</name>
+		///     </paramref>
+		///     is null. </exception>
+		/// <exception cref="UriFormatException">In the .NET for Windows Store apps or the Portable Class Library, catch the base class exception, <see cref="T:System.FormatException" />, instead.<paramref name="uriString" /> is empty.-or- The scheme specified in <paramref name="uriString" /> is not correctly formed. See <see cref="M:System.Uri.CheckSchemeName(System.String)" />.-or- <paramref name="uriString" /> contains too many slashes.-or- The password specified in <paramref name="uriString" /> is not valid.-or- The host name specified in <paramref name="uriString" /> is not valid.-or- The file name specified in <paramref name="uriString" /> is not valid. -or- The user name specified in <paramref name="uriString" /> is not valid.-or- The host or authority name specified in <paramref name="uriString" /> cannot be terminated by backslashes.-or- The port number specified in <paramref name="uriString" /> is not valid or cannot be parsed.-or- The length of <paramref name="uriString" /> exceeds 65519 characters.-or- The length of the scheme specified in <paramref name="uriString" /> exceeds 1023 characters.-or- There is an invalid character sequence in <paramref name="uriString" />.-or- The MS-DOS path specified in <paramref name="uriString" /> must start with c:\\.</exception>
+		/// <exception cref="MailChimpException">
+		/// Custom Mail Chimp Exception
+		/// </exception>
+		[Obsolete]
         public async Task<Campaign> AddOrUpdateAsync(string campaignId, Campaign campaign)
         {
             if (!string.IsNullOrWhiteSpace(campaignId))

--- a/MailChimp.Net/Models/Campaign.cs
+++ b/MailChimp.Net/Models/Campaign.cs
@@ -50,7 +50,7 @@ namespace MailChimp.Net.Models
         /// Gets or sets the emails sent.
         /// </summary>
         [JsonProperty("emails_sent")]
-        public int EmailsSent { get; set; }
+        public int? EmailsSent { get; set; }
 
         /// <summary>
         /// Gets or sets the id.


### PR DESCRIPTION
…t, separate out Add and Update on campaigns so that CampaignId is not sent through on patch, and most importantly remove the expect 100 from patch requests as it is not supported by Akamai