### PR TITLE
Implemented sort fields for GetAllAsync() and Test campaign with email in a test request

### DIFF
--- a/MailChimp.Net/Core/CampaignSortField.cs
+++ b/MailChimp.Net/Core/CampaignSortField.cs
@@ -1,0 +1,26 @@
+
+using System;
+using System.ComponentModel;
+
+namespace MailChimp.Net.Core
+{
+    /// <summary>
+    /// The campaign status.
+    /// </summary>
+    [Flags]
+    public enum CampaignSortField
+    {
+        /// <summary>
+        /// The send time.
+        /// </summary>
+        [Description("send_time")]
+        SendTime = 1,
+
+        /// <summary>
+        /// The send time.
+        /// </summary>
+        [Description("create_time")]
+        CreateTime = 2
+
+    }
+}

--- a/MailChimp.Net/Core/CampaignSortOrder.cs
+++ b/MailChimp.Net/Core/CampaignSortOrder.cs
@@ -1,0 +1,25 @@
+
+using System;
+using System.ComponentModel;
+
+namespace MailChimp.Net.Core
+{
+    /// <summary>
+    /// Sort order for sort_dir
+    /// </summary>
+    [Flags]
+    public enum CampaignSortOrder
+    {
+        /// <summary>
+        /// ASC
+        /// </summary>
+        [Description("ASC")]
+        ASC = 1,
+        /// <summary>
+        /// ASC
+        /// </summary>
+        [Description("DESC")]
+        DESC = 1
+    }
+
+}

--- a/MailChimp.Net/Core/MailChimpException.cs
+++ b/MailChimp.Net/Core/MailChimpException.cs
@@ -37,13 +37,13 @@ namespace MailChimp.Net.Core
         // ReSharper disable once UnusedParameter.Local
         public MailChimpException(SerializationInfo info, StreamingContext context)
         {
-            this.Detail = info?.GetString("detail");
-            this.Title = info?.GetString("title");
-            this.Type = info?.GetString("type");
-            this.Status = info?.GetInt32("status") ?? 0;
-            this.Instance = info?.GetString("instance");
-			try
-			{
+            try
+            {
+                this.Detail = info?.GetString("detail");
+                this.Title = info?.GetString("title");
+                this.Type = info?.GetString("type");
+                this.Status = info?.GetInt32("status") ?? 0;
+                this.Instance = info?.GetString("instance");
 				this.Errors = (List<Error>)info?.GetValue("errors", typeof(List<Error>));
 			}
 			catch

--- a/MailChimp.Net/Core/Requests/CampaignRequest.cs
+++ b/MailChimp.Net/Core/Requests/CampaignRequest.cs
@@ -23,6 +23,12 @@ namespace MailChimp.Net.Core
         public CampaignType? Type { get; set; }
 
         /// <summary>
+        /// Gets or sets the type.
+        /// </summary>
+        [QueryString("list_id")]
+        public string ListId { get; set; }
+
+        /// <summary>
         /// Gets or sets the sort_field.
         /// </summary>
         [QueryString("sort_field")]

--- a/MailChimp.Net/Core/Requests/CampaignRequest.cs
+++ b/MailChimp.Net/Core/Requests/CampaignRequest.cs
@@ -21,5 +21,18 @@ namespace MailChimp.Net.Core
         /// </summary>
         [QueryString("type")]
         public CampaignType? Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sort_field.
+        /// </summary>
+        [QueryString("sort_field")]
+        public CampaignSortField? SortField { get; set; }
+
+        /// <summary>
+        /// Gets or sets sort_dir.
+        /// </summary>
+        [QueryString("sort_dir")]
+        public CampaignSortOrder? SortOrder { get; set; }
     }
+
 }

--- a/MailChimp.Net/Core/Requests/CampaignScheduleRequest.cs
+++ b/MailChimp.Net/Core/Requests/CampaignScheduleRequest.cs
@@ -1,0 +1,42 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CampaignTestRequest.cs" company="Brandon Seydel">
+//   N/A
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System;
+
+using MailChimp.Net.Models;
+
+using Newtonsoft.Json;
+
+namespace MailChimp.Net.Core
+{
+    /// <summary>
+    /// The content request.
+    /// </summary>
+    public class CampaignScheduleRequest
+    {
+
+        /// <summary>
+        /// Gets or sets the schedule_time property in UTC  format
+        /// </summary>
+        [JsonProperty("schedule_time")]
+        public string ScheduleTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets 'timewarp' to send emails at localized time
+        /// </summary>
+        [JsonProperty("timewarp")]
+        public bool? Timewarp { get; set; }
+
+        /// <summary>
+        /// Choose whether the campaign should use Batch Delivery. Cannot be set to true for campaigns using Timewarp. 
+        /// </summary>
+        [JsonProperty("batch_delivery")]
+        public bool? BatchDelivery { get; set; }
+
+
+
+    }
+}

--- a/MailChimp.Net/Core/Requests/CampaignTestRequest.cs
+++ b/MailChimp.Net/Core/Requests/CampaignTestRequest.cs
@@ -1,0 +1,34 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CampaignTestRequest.cs" company="Brandon Seydel">
+//   N/A
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System;
+
+using MailChimp.Net.Models;
+
+using Newtonsoft.Json;
+
+namespace MailChimp.Net.Core
+{
+    /// <summary>
+    /// The content request.
+    /// </summary>
+    public class CampaignTestRequest
+    {
+
+        /// <summary>
+        /// Gets or sets the array of test email addresses
+        /// </summary>
+        [JsonProperty("test_emails")]
+        public string[] Emails { get; set; }
+
+        /// <summary>
+        /// Email type 'html' or 'plain_test'
+        /// </summary>
+        [JsonProperty("send_type")]
+        public string EmailType { get; set; }
+
+    }
+}

--- a/MailChimp.Net/Interfaces/ICampaignLogic.cs
+++ b/MailChimp.Net/Interfaces/ICampaignLogic.cs
@@ -110,6 +110,16 @@ namespace MailChimp.Net.Interfaces
         /// <returns></returns>
         Task ExecuteCampaignActionAsync(string campaignId, CampaignAction campaignAction);
 
+        ///<summary>
+        /// The test async.
+        /// </summary>
+        /// <param name="campaignId">
+        /// The campaign id.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        Task TestAsync(string campaignId, CampaignTestRequest content = null);
 
         /// <summary>
         /// The get all.

--- a/MailChimp.Net/Interfaces/ICampaignLogic.cs
+++ b/MailChimp.Net/Interfaces/ICampaignLogic.cs
@@ -121,6 +121,19 @@ namespace MailChimp.Net.Interfaces
         /// </returns>
         Task TestAsync(string campaignId, CampaignTestRequest content = null);
 
+
+        ///<summary>
+        /// The test async.
+        /// </summary>
+        /// <param name="campaignId">
+        /// The campaign id.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        Task ScheduleAsync(string campaignId, CampaignScheduleRequest content = null);
+
+
         /// <summary>
         /// The get all.
         /// </summary>

--- a/MailChimp.Net/Logic/CampaignLogic.cs
+++ b/MailChimp.Net/Logic/CampaignLogic.cs
@@ -404,6 +404,34 @@ namespace MailChimp.Net.Logic
             }
         }
 
+        /// <summary>
+        /// The send test request async.
+        /// </summary>
+        /// <param name="campaignId">
+        /// The campaign Id.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref>
+        ///         <name>requestUri</name>
+        ///     </paramref>
+        ///     was null.
+        /// </exception>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        /// <exception cref="UriFormatException">In the .NET for Windows Store apps or the Portable Class Library, catch the base class exception, <see cref="T:System.FormatException" />, instead.<paramref name="uriString" /> is empty.-or- The scheme specified in <paramref name="uriString" /> is not correctly formed. See <see cref="M:System.Uri.CheckSchemeName(System.String)" />.-or- <paramref name="uriString" /> contains too many slashes.-or- The password specified in <paramref name="uriString" /> is not valid.-or- The host name specified in <paramref name="uriString" /> is not valid.-or- The file name specified in <paramref name="uriString" /> is not valid. -or- The user name specified in <paramref name="uriString" /> is not valid.-or- The host or authority name specified in <paramref name="uriString" /> cannot be terminated by backslashes.-or- The port number specified in <paramref name="uriString" /> is not valid or cannot be parsed.-or- The length of <paramref name="uriString" /> exceeds 65519 characters.-or- The length of the scheme specified in <paramref name="uriString" /> exceeds 1023 characters.-or- There is an invalid character sequence in <paramref name="uriString" />.-or- The MS-DOS path specified in <paramref name="uriString" /> must start with c:\\.</exception>
+        /// <exception cref="MailChimpException">
+        /// Custom Mail Chimp Exception
+        /// </exception>
+        public async Task ScheduleAsync(string campaignId, CampaignScheduleRequest content = null)
+        {
+            using (var client = this.CreateMailClient("campaigns/"))
+            {
+                var response = await client.PostAsJsonAsync($"{campaignId}/actions/schedule", content, null).ConfigureAwait(false);
+                await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
+            }
+        }
+
 
         /// <summary>
         /// The send checklist async.

--- a/MailChimp.Net/Logic/CampaignLogic.cs
+++ b/MailChimp.Net/Logic/CampaignLogic.cs
@@ -377,6 +377,35 @@ namespace MailChimp.Net.Logic
 
 
         /// <summary>
+        /// The send test request async.
+        /// </summary>
+        /// <param name="campaignId">
+        /// The campaign Id.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref>
+        ///         <name>requestUri</name>
+        ///     </paramref>
+        ///     was null.
+        /// </exception>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        /// <exception cref="UriFormatException">In the .NET for Windows Store apps or the Portable Class Library, catch the base class exception, <see cref="T:System.FormatException" />, instead.<paramref name="uriString" /> is empty.-or- The scheme specified in <paramref name="uriString" /> is not correctly formed. See <see cref="M:System.Uri.CheckSchemeName(System.String)" />.-or- <paramref name="uriString" /> contains too many slashes.-or- The password specified in <paramref name="uriString" /> is not valid.-or- The host name specified in <paramref name="uriString" /> is not valid.-or- The file name specified in <paramref name="uriString" /> is not valid. -or- The user name specified in <paramref name="uriString" /> is not valid.-or- The host or authority name specified in <paramref name="uriString" /> cannot be terminated by backslashes.-or- The port number specified in <paramref name="uriString" /> is not valid or cannot be parsed.-or- The length of <paramref name="uriString" /> exceeds 65519 characters.-or- The length of the scheme specified in <paramref name="uriString" /> exceeds 1023 characters.-or- There is an invalid character sequence in <paramref name="uriString" />.-or- The MS-DOS path specified in <paramref name="uriString" /> must start with c:\\.</exception>
+        /// <exception cref="MailChimpException">
+        /// Custom Mail Chimp Exception
+        /// </exception>
+        public async Task TestAsync(string campaignId, CampaignTestRequest content = null)
+        {
+            using (var client = this.CreateMailClient("campaigns/"))
+            {
+                var response = await client.PostAsJsonAsync($"{campaignId}/actions/test", content, null).ConfigureAwait(false);
+                await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
+            }
+        }
+
+
+        /// <summary>
         /// The send checklist async.
         /// </summary>
         /// <param name="id">

--- a/MailChimp.Net/MailChimp.Net.csproj
+++ b/MailChimp.Net/MailChimp.Net.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Core\Operation.cs" />
     <Compile Include="Core\Requests\AuthorizedAppRequest.cs" />
     <Compile Include="Core\Requests\BatchRequest.cs" />
+    <Compile Include="Core\Requests\CampaignScheduleRequest.cs" />
     <Compile Include="Core\Requests\CampaignTestRequest.cs" />
     <Compile Include="Core\Requests\FileManagerFileRequest.cs" />
     <Compile Include="Core\Requests\InterestCategoryRequest.cs" />

--- a/MailChimp.Net/MailChimp.Net.csproj
+++ b/MailChimp.Net/MailChimp.Net.csproj
@@ -61,12 +61,15 @@
   <ItemGroup>
     <Compile Include="Core\BaseRequest.cs" />
     <Compile Include="Core\BaseResponse.cs" />
+    <Compile Include="Core\CampaignSortOrder.cs" />
+    <Compile Include="Core\CampaignSortField.cs" />
     <Compile Include="Core\Helper.cs" />
     <Compile Include="Core\HttpRequestExtensions.cs" />
     <Compile Include="Core\MailChimpException.cs" />
     <Compile Include="Core\Operation.cs" />
     <Compile Include="Core\Requests\AuthorizedAppRequest.cs" />
     <Compile Include="Core\Requests\BatchRequest.cs" />
+    <Compile Include="Core\Requests\CampaignTestRequest.cs" />
     <Compile Include="Core\Requests\FileManagerFileRequest.cs" />
     <Compile Include="Core\Requests\InterestCategoryRequest.cs" />
     <Compile Include="Core\Batch.cs" />

--- a/MailChimp.Net/Models/Clicks.cs
+++ b/MailChimp.Net/Models/Clicks.cs
@@ -17,7 +17,7 @@ namespace MailChimp.Net.Models
         /// Gets or sets the click rate.
         /// </summary>
         [JsonProperty("click_rate")]
-        public int ClickRate { get; set; }
+        public double ClickRate { get; set; }
 
         /// <summary>
         /// Gets or sets the clicks total.

--- a/MailChimp.Net/Models/ConditionType.cs
+++ b/MailChimp.Net/Models/ConditionType.cs
@@ -67,6 +67,13 @@ namespace MailChimp.Net.Models
         [Description("social_influence")]
         SocialInfluence,
         [Description("social_network")]
-        SocialNetwork,
+        SocialNetwork,        
+        [Description("Date")]
+        Date,
+        [Description("Interests")]
+        Interests,
+        [Description("DateMerge")]
+        DateMerge
+
     }
 }

--- a/MailChimp.Net/Models/ListStats.cs
+++ b/MailChimp.Net/Models/ListStats.cs
@@ -17,24 +17,24 @@ namespace MailChimp.Net.Models
         /// Gets or sets the click rate.
         /// </summary>
         [JsonProperty("click_rate")]
-        public int ClickRate { get; set; }
+        public double ClickRate { get; set; }
 
         /// <summary>
         /// Gets or sets the open rate.
         /// </summary>
         [JsonProperty("open_rate")]
-        public int OpenRate { get; set; }
+        public double OpenRate { get; set; }
 
         /// <summary>
         /// Gets or sets the sub rate.
         /// </summary>
         [JsonProperty("sub_rate")]
-        public int SubRate { get; set; }
+        public double SubRate { get; set; }
 
         /// <summary>
         /// Gets or sets the unsub rate.
         /// </summary>
         [JsonProperty("unsub_rate")]
-        public int UnsubRate { get; set; }
+        public double UnsubRate { get; set; }
     }
 }

--- a/MailChimp.Net/Models/MemberStats.cs
+++ b/MailChimp.Net/Models/MemberStats.cs
@@ -10,8 +10,8 @@ namespace MailChimp.Net.Models
     public class MemberStats
     {
         [JsonProperty("avg_open_rate")]
-        public int AverageOpenRate { get; set; }
+        public double AverageOpenRate { get; set; }
         [JsonProperty("avg_click_rate")]
-        public int AverageClickRate { get; set; }
+        public double AverageClickRate { get; set; }
     }
 }

--- a/MailChimp.Net/Models/Opens.cs
+++ b/MailChimp.Net/Models/Opens.cs
@@ -23,7 +23,7 @@ namespace MailChimp.Net.Models
         /// Gets or sets the open rate.
         /// </summary>
         [JsonProperty("open_rate")]
-        public int OpenRate { get; set; }
+        public double OpenRate { get; set; }
 
         /// <summary>
         /// Gets or sets the opens total.

--- a/MailChimp.Net/Models/Operator.cs
+++ b/MailChimp.Net/Models/Operator.cs
@@ -95,6 +95,9 @@ namespace MailChimp.Net.Models
         [Description("follow")]
         Follow,
         [Description("notfollow")]
-        NotFollow
+        NotFollow,
+        [Description("interestcontains")]
+        InterestContains
+
     }
 }

--- a/MailChimp.Net/Models/ReportSummary.cs
+++ b/MailChimp.Net/Models/ReportSummary.cs
@@ -17,7 +17,7 @@ namespace MailChimp.Net.Models
         /// Gets or sets the click rate.
         /// </summary>
         [JsonProperty("click_rate")]
-        public int ClickRate { get; set; }
+        public double ClickRate { get; set; }
 
         /// <summary>
         /// Gets or sets the clicks.
@@ -29,7 +29,7 @@ namespace MailChimp.Net.Models
         /// Gets or sets the open rate.
         /// </summary>
         [JsonProperty("open_rate")]
-        public int OpenRate { get; set; }
+        public double OpenRate { get; set; }
 
         /// <summary>
         /// Gets or sets the opens.

--- a/MailChimp.Net/Models/Stats.cs
+++ b/MailChimp.Net/Models/Stats.cs
@@ -17,13 +17,13 @@ namespace MailChimp.Net.Models
         /// Gets or sets the avg sub rate.
         /// </summary>
         [JsonProperty("avg_sub_rate")]
-        public int AvgSubRate { get; set; }
+        public double AvgSubRate { get; set; }
 
         /// <summary>
         /// Gets or sets the avg unsub rate.
         /// </summary>
         [JsonProperty("avg_unsub_rate")]
-        public int AvgUnsubRate { get; set; }
+        public double AvgUnsubRate { get; set; }
 
         /// <summary>
         /// Gets or sets the campaign count.
@@ -53,7 +53,7 @@ namespace MailChimp.Net.Models
         /// Gets or sets the click rate.
         /// </summary>
         [JsonProperty("click_rate")]
-        public decimal ClickRate { get; set; }
+        public double ClickRate { get; set; }
 
         /// <summary>
         /// Gets or sets the last sub date.
@@ -89,13 +89,13 @@ namespace MailChimp.Net.Models
         /// Gets or sets the open rate.
         /// </summary>
         [JsonProperty("open_rate")]
-        public decimal OpenRate { get; set; }
+        public double OpenRate { get; set; }
 
         /// <summary>
         /// Gets or sets the target sub rate.
         /// </summary>
         [JsonProperty("target_sub_rate")]
-        public int TargetSubRate { get; set; }
+        public double TargetSubRate { get; set; }
 
         /// <summary>
         /// Gets or sets the unsubscribe count.


### PR DESCRIPTION
I have created following new enums and properties to implement more filters in CampaignLogic. GetAllAsync()

```
CampaignSortField - 'send_time', 'create_time'

CampaignSortOrder - 'ASC', 'DESC'
```

I have added more exception suppression in class MailChimpException.

I have implemented CamapignLogic.TestAsync() with Requests.CampaignTestRequest that supplies test email as a string.

