### PR TITLE
Adding ExistsAsync to MemberLogic

### DIFF
--- a/MailChimp.Net.Tests/ListMemberTest.cs
+++ b/MailChimp.Net.Tests/ListMemberTest.cs
@@ -66,6 +66,45 @@ namespace MailChimp.Net.Tests
         }
 
         /// <summary>
+        /// The should_ return_true_if_member_exists_in_list.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [TestMethod]
+        public async Task Should_Return_True_If_Member_Exists_In_List()
+        {
+            var emailAddress = $"{this._ticks}@test.com";
+            await
+                this._mailChimpManager.Members.AddOrUpdateAsync(
+                    this.TestList.Id,
+                    new Member { EmailAddress = emailAddress, Status = Status.Subscribed }).ConfigureAwait(false);
+
+            var exists = await this._mailChimpManager.Members.ExistsAsync(this.TestList.Id, emailAddress);
+            Assert.IsTrue(exists);
+        }
+
+        /// <summary>
+        /// The should_ return_false_if_member_does_not_exist_in_list.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [TestMethod]
+        public async Task Should_Return_False_If_Member_Does_Not_Exists_In_List()
+        {
+            var emailAddress1 = $"{this._ticks}1@test.com";
+            var emailAddress2 = $"{this._ticks}2@test.com";
+            await
+                this._mailChimpManager.Members.AddOrUpdateAsync(
+                    this.TestList.Id,
+                    new Member { EmailAddress = emailAddress1, Status = Status.Subscribed }).ConfigureAwait(false);
+
+            var exists = await this._mailChimpManager.Members.ExistsAsync(this.TestList.Id, emailAddress2);
+            Assert.IsFalse(exists);
+        }
+
+        /// <summary>
         /// The should_ return_ one_ unsubscribed_ member.
         /// </summary>
         /// <returns>

--- a/MailChimp.Net/Interfaces/IMemberLogic.cs
+++ b/MailChimp.Net/Interfaces/IMemberLogic.cs
@@ -91,19 +91,34 @@ namespace MailChimp.Net.Interfaces
 		/// </returns>
 		Task<Member> GetAsync(string listId, string emailAddress, BaseRequest request = null);
 
-		/// <exception cref="ArgumentNullException"><paramref>
-		///         <name>uriString</name>
-		///     </paramref>
-		///     is null. </exception>
-		/// <exception cref="UriFormatException">In the .NET for Windows Store apps or the Portable Class Library, catch the base class exception, <see cref="T:System.FormatException" />, instead.<paramref name="uriString" /> is empty.-or- The scheme specified in <paramref name="uriString" /> is not correctly formed. See <see cref="M:System.Uri.CheckSchemeName(System.String)" />.-or- <paramref name="uriString" /> contains too many slashes.-or- The password specified in <paramref name="uriString" /> is not valid.-or- The host name specified in <paramref name="uriString" /> is not valid.-or- The file name specified in <paramref name="uriString" /> is not valid. -or- The user name specified in <paramref name="uriString" /> is not valid.-or- The host or authority name specified in <paramref name="uriString" /> cannot be terminated by backslashes.-or- The port number specified in <paramref name="uriString" /> is not valid or cannot be parsed.-or- The length of <paramref name="uriString" /> exceeds 65519 characters.-or- The length of the scheme specified in <paramref name="uriString" /> exceeds 1023 characters.-or- There is an invalid character sequence in <paramref name="uriString" />.-or- The MS-DOS path specified in <paramref name="uriString" /> must start with c:\\.</exception>
-		/// <exception cref="InvalidOperationException">This member belongs to a type that is loaded into the reflection-only context. See How to: Load Assemblies into the Reflection-Only Context.</exception>
-		/// <exception cref="MailChimpException">
-		/// Custom Mail Chimp Exception
-		/// </exception>
-		/// <exception cref="NotSupportedException"><paramref name="element" /> is not a constructor, method, property, event, type, or field. </exception>
-		/// <exception cref="TypeLoadException">A custom attribute type cannot be loaded. </exception>
-		/// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="P:System.Text.StringBuilder.MaxCapacity" />. </exception>
-		Task<MemberResponse> GetResponseAsync(string listId, MemberRequest memberRequest = null);
+        /// <summary>
+        /// The check if exists async.
+        /// </summary>
+        /// <param name="listId">
+        /// The list id.
+        /// </param>
+        /// <param name="emailAddress">
+		/// </param>
+		/// <param name="request"></param>
+        /// The email address.
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        Task<bool> ExistsAsync(string listId, string emailAddress, BaseRequest request = null);
+
+        /// <exception cref="ArgumentNullException"><paramref>
+        ///         <name>uriString</name>
+        ///     </paramref>
+        ///     is null. </exception>
+        /// <exception cref="UriFormatException">In the .NET for Windows Store apps or the Portable Class Library, catch the base class exception, <see cref="T:System.FormatException" />, instead.<paramref name="uriString" /> is empty.-or- The scheme specified in <paramref name="uriString" /> is not correctly formed. See <see cref="M:System.Uri.CheckSchemeName(System.String)" />.-or- <paramref name="uriString" /> contains too many slashes.-or- The password specified in <paramref name="uriString" /> is not valid.-or- The host name specified in <paramref name="uriString" /> is not valid.-or- The file name specified in <paramref name="uriString" /> is not valid. -or- The user name specified in <paramref name="uriString" /> is not valid.-or- The host or authority name specified in <paramref name="uriString" /> cannot be terminated by backslashes.-or- The port number specified in <paramref name="uriString" /> is not valid or cannot be parsed.-or- The length of <paramref name="uriString" /> exceeds 65519 characters.-or- The length of the scheme specified in <paramref name="uriString" /> exceeds 1023 characters.-or- There is an invalid character sequence in <paramref name="uriString" />.-or- The MS-DOS path specified in <paramref name="uriString" /> must start with c:\\.</exception>
+        /// <exception cref="InvalidOperationException">This member belongs to a type that is loaded into the reflection-only context. See How to: Load Assemblies into the Reflection-Only Context.</exception>
+        /// <exception cref="MailChimpException">
+        /// Custom Mail Chimp Exception
+        /// </exception>
+        /// <exception cref="NotSupportedException"><paramref name="element" /> is not a constructor, method, property, event, type, or field. </exception>
+        /// <exception cref="TypeLoadException">A custom attribute type cannot be loaded. </exception>
+        /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="P:System.Text.StringBuilder.MaxCapacity" />. </exception>
+        Task<MemberResponse> GetResponseAsync(string listId, MemberRequest memberRequest = null);
 
 		string Hash(string emailAddress);
 	}

--- a/MailChimp.Net/Logic/MemberLogic.cs
+++ b/MailChimp.Net/Logic/MemberLogic.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using MailChimp.Net.Core;
 using MailChimp.Net.Interfaces;
 using MailChimp.Net.Models;
+using System.Net;
 #pragma warning disable 1584, 1711, 1572, 1581, 1580
 
 // ReSharper disable UnusedMember.Local
@@ -316,6 +317,37 @@ namespace MailChimp.Net.Logic
                 var response = await client.GetAsync($"{listId}/members/{this.Hash(emailAddress.ToLower())}{request?.ToQueryString()}").ConfigureAwait(false);
                 await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
                 return await response.Content.ReadAsAsync<Member>().ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// The get async.
+        /// </summary>
+        /// <param name="listId">
+        /// The list id.
+        /// </param>
+        /// <param name="emailAddress">
+        /// The email address.
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        public async Task<bool> ExistsAsync(string listId, string emailAddress, BaseRequest request = null)
+        {
+            using (var client = this.CreateMailClient($"{BaseUrl}/"))
+            {
+                var response = await client.GetAsync($"{listId}/members/{this.Hash(emailAddress.ToLower())}{request?.ToQueryString()}").ConfigureAwait(false);
+                if (response.IsSuccessStatusCode)
+                {
+                    return true;
+                }
+
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return false;
+                }
+
+                await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
+                return false;
             }
         }
 


### PR DESCRIPTION
Adding ExistsAsync with tests for MemberLogic to allow me to check if a user exists in MailChimp without having to catch an error and deriving logic that way.