### PR TITLE
fixed typo in IReportLogic - GetSentToRecipientResponseAsync->GetSent…

### DIFF
--- a/MailChimp.Net/Core/Batch.cs
+++ b/MailChimp.Net/Core/Batch.cs
@@ -25,7 +25,7 @@ namespace MailChimp.Net.Core
 		public int TotalOperations { get; set; }
 
 	    [System.ComponentModel.Browsable(false), Obsolete("Spelling corrected to FinishedOperations"), JsonIgnore]
-	    public string FinishedOperpations
+	    public int FinishedOperpations
 	    {
 	        get { return this.FinishedOperations; }
 	        set { this.FinishedOperations = value; }
@@ -35,25 +35,25 @@ namespace MailChimp.Net.Core
 		/// The number of completed operations. This includes operations that returned an error.
 		/// </summary>
 		[JsonProperty("finished_operations")]
-		public string FinishedOperations { get; set; }
+		public int FinishedOperations { get; set; }
 
 		/// <summary>
 		/// The number of completed operations that returned an error.
 		/// </summary>
 		[JsonProperty("errored_operations")]
-		public string ErroredOperations { get; set; }
+		public int ErroredOperations { get; set; }
 
 		/// <summary>
 		/// The time and date when the server received the batch request.
 		/// </summary>
 		[JsonProperty("submitted_at")]
-		public string SubmittedAt { get; set; }
+		public DateTime? SubmittedAt { get; set; }
 
 		/// <summary>
 		/// The time and date when all operations in the batch request completed.
 		/// </summary>
 		[JsonProperty("completed_at")]
-		public string CompletedAt { get; set; }
+		public DateTime? CompletedAt { get; set; }
 
 		/// <summary>
 		/// The URL of the gzipped archive of the results of all the operations.

--- a/MailChimp.Net/Interfaces/IReportLogic.cs
+++ b/MailChimp.Net/Interfaces/IReportLogic.cs
@@ -19,7 +19,7 @@ namespace MailChimp.Net.Interfaces
     /// </summary>
     public interface IReportLogic
     {
-        Task<SentToResponse> GetSentToRecipientResponseAsync(string campaignId, QueryableBaseRequest request = null);
+        Task<SentToResponse> GetSentToRecipientsResponseAsync(string campaignId, QueryableBaseRequest request = null);
         Task<IEnumerable<Report>> GetAllReportsAsync(ReportRequest request = null);
         Task<IEnumerable<Advice>> GetCampaignAdviceAsync(string campaignId, BaseRequest request = null);
         Task<IEnumerable<UrlClicked>> GetClickReportAsync(string campaignId, QueryableBaseRequest request = null);

--- a/MailChimp.Net/Logic/CampaignFolderLogic.cs
+++ b/MailChimp.Net/Logic/CampaignFolderLogic.cs
@@ -23,7 +23,7 @@ namespace MailChimp.Net.Logic
     internal class CampaignFolderLogic : BaseLogic, ICampaignFolderLogic
     {
 
-        private const string BaseUrl = "campagin-folders";
+        private const string BaseUrl = "campaign-folders";
 
         public CampaignFolderLogic(string apiKey)
             : base(apiKey)

--- a/MailChimp.Net/Logic/ReportLogic.cs
+++ b/MailChimp.Net/Logic/ReportLogic.cs
@@ -616,7 +616,7 @@ namespace MailChimp.Net.Logic
         /// <exception cref="TypeLoadException">A custom attribute type cannot be loaded. </exception>
         public async Task<IEnumerable<SentTo>> GetSentToRecipientsAsync(string campaignId, QueryableBaseRequest request = null)
         {
-            return (await this.GetSentToRecipientResponseAsync(campaignId, request))?.Recipients;
+            return (await this.GetSentToRecipientsResponseAsync(campaignId, request))?.Recipients;
         }
 
 
@@ -626,7 +626,7 @@ namespace MailChimp.Net.Logic
         /// <param name="campaignId"></param>
         /// <param name="request"></param>
         /// <returns></returns>
-        public async Task<SentToResponse> GetSentToRecipientResponseAsync(string campaignId, QueryableBaseRequest request = null)
+        public async Task<SentToResponse> GetSentToRecipientsResponseAsync(string campaignId, QueryableBaseRequest request = null)
         {
             using (var client = this.CreateMailClient("reports/"))
             {

--- a/MailChimp.Net/Models/Campaign.cs
+++ b/MailChimp.Net/Models/Campaign.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
 using MailChimp.Net.Core;
 using Newtonsoft.Json;
 
@@ -30,7 +31,7 @@ namespace MailChimp.Net.Models
         /// Gets or sets the create time.
         /// </summary>
         [JsonProperty("create_time")]
-        public string CreateTime { get; set; }
+        public DateTime CreateTime { get; set; }
 
         /// <summary>
         /// Gets or sets the delivery status.
@@ -75,7 +76,7 @@ namespace MailChimp.Net.Models
         /// Gets or sets the send time.
         /// </summary>
         [JsonProperty("send_time")]
-        public string SendTime { get; set; }
+        public DateTime? SendTime { get; set; }
 
         /// <summary>
         /// Gets or sets the settings.

--- a/MailChimp.Net/Models/Clicks.cs
+++ b/MailChimp.Net/Models/Clicks.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
 using Newtonsoft.Json;
 
 namespace MailChimp.Net.Models
@@ -29,7 +30,7 @@ namespace MailChimp.Net.Models
         /// Gets or sets the last click.
         /// </summary>
         [JsonProperty("last_click")]
-        public string LastClick { get; set; }
+        public DateTime? LastClick { get; set; }
 
         /// <summary>
         /// Gets or sets the unique clicks.

--- a/MailChimp.Net/Models/EepClick.cs
+++ b/MailChimp.Net/Models/EepClick.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 
 using Newtonsoft.Json;
@@ -25,13 +26,13 @@ namespace MailChimp.Net.Models
         /// Gets or sets the first click.
         /// </summary>
         [JsonProperty("first_click")]
-        public string FirstClick { get; set; }
+        public DateTime? FirstClick { get; set; }
 
         /// <summary>
         /// Gets or sets the last click.
         /// </summary>
         [JsonProperty("last_click")]
-        public string LastClick { get; set; }
+        public DateTime? LastClick { get; set; }
 
         /// <summary>
         /// Gets or sets the locations.

--- a/MailChimp.Net/Models/List.cs
+++ b/MailChimp.Net/Models/List.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 
 using Newtonsoft.Json;
@@ -11,127 +12,127 @@ using MailChimp.Net.Core;
 
 namespace MailChimp.Net.Models
 {
-	/// <summary>
-	/// The list.
-	/// </summary>
-	public class List
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="List"/> class.
-		/// </summary>
-		public List()
-		{
-			this.Links = new HashSet<Link>();
-		    Visibility = Visibility.Private;
-		}
+    /// <summary>
+    /// The list.
+    /// </summary>
+    public class List
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="List"/> class.
+        /// </summary>
+        public List()
+        {
+            this.Links = new HashSet<Link>();
+            Visibility = Visibility.Private;
+        }
 
-		/// <summary>
-		/// Gets or sets the beamer address.
-		/// </summary>
-		[JsonProperty("beamer_address")]
-		public string BeamerAddress { get; set; }
+        /// <summary>
+        /// Gets or sets the beamer address.
+        /// </summary>
+        [JsonProperty("beamer_address")]
+        public string BeamerAddress { get; set; }
 
-		/// <summary>
-		/// Gets or sets the campaign defaults.
-		/// </summary>
-		[JsonProperty("campaign_defaults")]
-		public CampaignDefaults CampaignDefaults { get; set; }
+        /// <summary>
+        /// Gets or sets the campaign defaults.
+        /// </summary>
+        [JsonProperty("campaign_defaults")]
+        public CampaignDefaults CampaignDefaults { get; set; }
 
-		/// <summary>
-		/// Gets or sets the contact.
-		/// </summary>
-		[JsonProperty("contact")]
-		public Contact Contact { get; set; }
+        /// <summary>
+        /// Gets or sets the contact.
+        /// </summary>
+        [JsonProperty("contact")]
+        public Contact Contact { get; set; }
 
-		/// <summary>
-		/// Gets or sets the date created.
-		/// </summary>
-		[JsonProperty("date_created")]
-		public string DateCreated { get; set; }
+        /// <summary>
+        /// Gets or sets the date created.
+        /// </summary>
+        [JsonProperty("date_created")]
+        public DateTime DateCreated { get; set; }
 
-		/// <summary>
-		/// Gets or sets a value indicating whether email type option.
-		/// </summary>
-		[JsonProperty("email_type_option")]
-		public bool EmailTypeOption { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether email type option.
+        /// </summary>
+        [JsonProperty("email_type_option")]
+        public bool EmailTypeOption { get; set; }
 
-		/// <summary>
-		/// Gets or sets the id.
-		/// </summary>
-		[JsonProperty("id")]
-		public string Id { get; set; }
+        /// <summary>
+        /// Gets or sets the id.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-		/// <summary>
-		/// Gets or sets the links.
-		/// </summary>
-		[JsonProperty("_links")]
-		public IEnumerable<Link> Links { get; set; }
+        /// <summary>
+        /// Gets or sets the links.
+        /// </summary>
+        [JsonProperty("_links")]
+        public IEnumerable<Link> Links { get; set; }
 
-		/// <summary>
-		/// Gets or sets the list rating.
-		/// </summary>
-		[JsonProperty("list_rating")]
-		public int ListRating { get; set; }
+        /// <summary>
+        /// Gets or sets the list rating.
+        /// </summary>
+        [JsonProperty("list_rating")]
+        public int ListRating { get; set; }
 
-		/// <summary>
-		/// Gets or sets the modules.
-		/// </summary>
-		[JsonProperty("modules")]
-		public object[] Modules { get; set; }
+        /// <summary>
+        /// Gets or sets the modules.
+        /// </summary>
+        [JsonProperty("modules")]
+        public object[] Modules { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name.
-		/// </summary>
-		[JsonProperty("name")]
-		public string Name { get; set; }
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
 
-		/// <summary>
-		/// Gets or sets the notify on subscribe.
-		/// </summary>
-		[JsonProperty("notify_on_subscribe")]
-		public string NotifyOnSubscribe { get; set; }
+        /// <summary>
+        /// Gets or sets the notify on subscribe.
+        /// </summary>
+        [JsonProperty("notify_on_subscribe")]
+        public string NotifyOnSubscribe { get; set; }
 
-		/// <summary>
-		/// Gets or sets the notify on unsubscribe.
-		/// </summary>
-		[JsonProperty("notify_on_unsubscribe")]
-		public string NotifyOnUnsubscribe { get; set; }
+        /// <summary>
+        /// Gets or sets the notify on unsubscribe.
+        /// </summary>
+        [JsonProperty("notify_on_unsubscribe")]
+        public string NotifyOnUnsubscribe { get; set; }
 
-		/// <summary>
-		/// Gets or sets the permission reminder.
-		/// </summary>
-		[JsonProperty("permission_reminder")]
-		public string PermissionReminder { get; set; }
+        /// <summary>
+        /// Gets or sets the permission reminder.
+        /// </summary>
+        [JsonProperty("permission_reminder")]
+        public string PermissionReminder { get; set; }
 
-		/// <summary>
-		/// Gets or sets the stats.
-		/// </summary>
-		[JsonProperty("stats")]
-		public Stats Stats { get; set; }
+        /// <summary>
+        /// Gets or sets the stats.
+        /// </summary>
+        [JsonProperty("stats")]
+        public Stats Stats { get; set; }
 
-		/// <summary>
-		/// Gets or sets the subscribe url long.
-		/// </summary>
-		[JsonProperty("subscribe_url_long")]
-		public string SubscribeUrlLong { get; set; }
+        /// <summary>
+        /// Gets or sets the subscribe url long.
+        /// </summary>
+        [JsonProperty("subscribe_url_long")]
+        public string SubscribeUrlLong { get; set; }
 
-		/// <summary>
-		/// Gets or sets the subscribe url short.
-		/// </summary>
-		[JsonProperty("subscribe_url_short")]
-		public string SubscribeUrlShort { get; set; }
+        /// <summary>
+        /// Gets or sets the subscribe url short.
+        /// </summary>
+        [JsonProperty("subscribe_url_short")]
+        public string SubscribeUrlShort { get; set; }
 
-		/// <summary>
-		/// Gets or sets a value indicating whether use archive bar.
-		/// </summary>
-		[JsonProperty("use_archive_bar")]
-		public bool UseArchiveBar { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether use archive bar.
+        /// </summary>
+        [JsonProperty("use_archive_bar")]
+        public bool UseArchiveBar { get; set; }
 
-		/// <summary>
-		/// Gets or sets the visibility.
-		/// </summary>
-		[JsonProperty("visibility")]
+        /// <summary>
+        /// Gets or sets the visibility.
+        /// </summary>
+        [JsonProperty("visibility")]
         [JsonConverter(typeof(StringEnumDescriptionConverter))]
-		public Visibility Visibility { get; set; }
-	}
+        public Visibility Visibility { get; set; }
+    }
 }

--- a/MailChimp.Net/Models/Opens.cs
+++ b/MailChimp.Net/Models/Opens.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
 using Newtonsoft.Json;
 
 namespace MailChimp.Net.Models
@@ -17,7 +18,7 @@ namespace MailChimp.Net.Models
         /// Gets or sets the last open.
         /// </summary>
         [JsonProperty("last_open")]
-        public string LastOpen { get; set; }
+        public DateTime? LastOpen { get; set; }
 
         /// <summary>
         /// Gets or sets the open rate.

--- a/MailChimp.Net/Models/Referrer.cs
+++ b/MailChimp.Net/Models/Referrer.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
 using Newtonsoft.Json;
 
 namespace MailChimp.Net.Models
@@ -23,13 +24,13 @@ namespace MailChimp.Net.Models
         /// Gets or sets the first click.
         /// </summary>
         [JsonProperty("first_click")]
-        public string FirstClick { get; set; }
+        public DateTime? FirstClick { get; set; }
 
         /// <summary>
         /// Gets or sets the last click.
         /// </summary>
         [JsonProperty("last_click")]
-        public string LastClick { get; set; }
+        public DateTime? LastClick { get; set; }
 
         /// <summary>
         /// Gets or sets the name.

--- a/MailChimp.Net/Models/SentTo.cs
+++ b/MailChimp.Net/Models/SentTo.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
 using Newtonsoft.Json;
 
 namespace MailChimp.Net.Models
@@ -47,7 +48,7 @@ namespace MailChimp.Net.Models
         /// Gets or sets the last open.
         /// </summary>
         [JsonProperty("last_open")]
-        public string LastOpen { get; set; }
+        public DateTime? LastOpen { get; set; }
 
         /// <summary>
         /// Gets or sets the links.

--- a/MailChimp.Net/Models/UrlsClicked.cs
+++ b/MailChimp.Net/Models/UrlsClicked.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 
 using Newtonsoft.Json;
@@ -45,7 +46,7 @@ namespace MailChimp.Net.Models
         /// Gets or sets the last click.
         /// </summary>
         [JsonProperty("last_click")]
-        public string LastClick { get; set; }
+        public DateTime? LastClick { get; set; }
 
         /// <summary>
         /// Gets or sets the links.


### PR DESCRIPTION
* Changed types of Batch to reflect types as documented in the API.
* Fixed typo in campaign folders endpoint (was campagin-folders - should be campaign-folders).
* Rename IReportLogic GetSentToRecipientResponseAsync to GetSentToRecipientsResponseAsync to reflect the non-response versions.
* Changed certain properties from string to DateTime or DateTime? where appopriate; since the API returns dates in ISO8601 format (and this is the default supported format for JSON.NET, the conversions happen automatically).