### PR TITLE
Added missing properties to campaign request and report and add none-status.

### DIFF
--- a/MailChimp.Net/Core/Requests/CampaignRequest.cs
+++ b/MailChimp.Net/Core/Requests/CampaignRequest.cs
@@ -26,10 +26,16 @@ namespace MailChimp.Net.Core
         public CampaignType? Type { get; set; }
 
         /// <summary>
-        /// Gets or sets the type.
+        /// Gets or sets the list id.
         /// </summary>
         [QueryString("list_id")]
         public string ListId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the folder id.
+        /// </summary>
+        [QueryString("folder_id")]
+        public string FolderId { get; set; }
 
         /// <summary>
         /// Gets or sets the sort_field.

--- a/MailChimp.Net/Logic/CampaignFolderLogic.cs
+++ b/MailChimp.Net/Logic/CampaignFolderLogic.cs
@@ -55,7 +55,7 @@ namespace MailChimp.Net.Logic
 
         public async Task<CampaignFolderResponse> GetResponseAsync(QueryableBaseRequest request = null)
         {
-            request = new QueryableBaseRequest
+            request = request ?? new QueryableBaseRequest
             {
                 Limit = base._limit
             };

--- a/MailChimp.Net/Logic/ListLogic.cs
+++ b/MailChimp.Net/Logic/ListLogic.cs
@@ -149,7 +149,7 @@ namespace MailChimp.Net.Logic
         /// <exception cref="TypeLoadException">A custom attribute type cannot be loaded. </exception>
         public async Task<ListResponse> GetResponseAsync(ListRequest request = null)
         {
-            request = new ListRequest
+            request = request ?? new ListRequest
             {
                 Limit = base._limit
             };

--- a/MailChimp.Net/Models/Report.cs
+++ b/MailChimp.Net/Models/Report.cs
@@ -73,6 +73,24 @@ namespace MailChimp.Net.Models
         public Forwards Forwards { get; set; }
 
         /// <summary>
+        /// Gets or sets the subject line.
+        /// </summary>
+        [JsonProperty("subject_line")]
+        public string SubjectLine { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list name.
+        /// </summary>
+        [JsonProperty("list_name")]
+        public string ListName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list id.
+        /// </summary>
+        [JsonProperty("list_id")]
+        public string ListId { get; set; }
+
+        /// <summary>
         /// Gets or sets the id.
         /// </summary>
         [JsonProperty("id")]

--- a/MailChimp.Net/Models/Status.cs
+++ b/MailChimp.Net/Models/Status.cs
@@ -35,6 +35,12 @@ namespace MailChimp.Net.Models
         /// The pending.
         /// </summary>
         [Description("pending")]
-        Pending
+        Pending,
+
+        /// <summary>
+        /// The none.
+        /// </summary>
+        [Description("")]
+        None
     }
 }


### PR DESCRIPTION
See issues #111 and #80 

The addition of the "none" description closes an already-closed issue #80 - not sure if this was ever done or if I'm missing something.

Also - there was a similar issue to #110 where the request wasn't being used in ListLogic or CampaignFolderLogic.

Thanks!
