### PR TITLE
Fix for contact info on API resource. Add possibility to add new webhook.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,3 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
-//Ingore Test
-
-MailChimp.Net.Tests/*

--- a/MailChimp.Net.Tests/ApiTest.cs
+++ b/MailChimp.Net.Tests/ApiTest.cs
@@ -1,35 +1,31 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ApiTest.cs" company="Brandon Seydel">
+// <copyright file="AuthorizedAppTest.cs" company="Brandon Seydel">
 //   N/A
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
 using System.Threading.Tasks;
-
+using MailChimp.Net.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace MailChimp.Net.Tests
 {
     /// <summary>
-    /// The authorized app test.
+    /// The api test.
     /// </summary>
     [TestClass]
-    public class AuthorizedAppTest : MailChimpTest
+    public class ApiTest : MailChimpTest
     {
         /// <summary>
-        /// The should_ return_ app_ information.
+        /// The should_ return_ ap i_ information.
         /// </summary>
         /// <returns>
         /// The <see cref="Task"/>.
         /// </returns>
         [TestMethod]
-        public async Task Should_Return_App_Information()
+        public async Task Should_Return_API_Information()
         {
-            var apiInfo = await this._mailChimpManager.Apps.GetAllAsync();
-            apiInfo = await this._mailChimpManager.Configure(new MailChimpConfiguration
-            {
-                Limit = 100000
-            }).Apps.GetAllAsync();
+            var apiInfo = await this._mailChimpManager.Api.GetInfoAsync();
             Assert.IsNotNull(apiInfo);
         }
     }

--- a/MailChimp.Net.Tests/AuthorizedAppTest.cs
+++ b/MailChimp.Net.Tests/AuthorizedAppTest.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="AuthorizedAppTest.cs" company="Brandon Seydel">
+// <copyright file="ApiTest.cs" company="Brandon Seydel">
 //   N/A
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
@@ -11,21 +11,25 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace MailChimp.Net.Tests
 {
     /// <summary>
-    /// The api test.
+    /// The authorized app test.
     /// </summary>
     [TestClass]
-    public class ApiTest : MailChimpTest
+    public class AuthorizedAppTest : MailChimpTest
     {
         /// <summary>
-        /// The should_ return_ ap i_ information.
+        /// The should_ return_ app_ information.
         /// </summary>
         /// <returns>
         /// The <see cref="Task"/>.
         /// </returns>
         [TestMethod]
-        public async Task Should_Return_API_Information()
+        public async Task Should_Return_App_Information()
         {
-            var apiInfo = await this._mailChimpManager.Api.GetInfoAsync();
+            var apiInfo = await this._mailChimpManager.Apps.GetAllAsync();
+            apiInfo = await this._mailChimpManager.Configure(new MailChimpConfiguration
+            {
+                Limit = 100000
+            }).Apps.GetAllAsync();
             Assert.IsNotNull(apiInfo);
         }
     }

--- a/MailChimp.Net.Tests/ListMemberTest.cs
+++ b/MailChimp.Net.Tests/ListMemberTest.cs
@@ -29,7 +29,7 @@ namespace MailChimp.Net.Tests
         public void InitilizeListMemberTest()
         {
             this.ClearMailChimpAsync().Wait();
-            var createdList = this._mailChimpManager.Lists.AddOrUpdateAsync(this.MailChimpList).Result;
+            var createdList = this._mailChimpManager.Lists.AddOrUpdateAsync(this.GetMailChimpList()).Result;
             this.TestList = createdList;
         }
 

--- a/MailChimp.Net.Tests/ListTest.cs
+++ b/MailChimp.Net.Tests/ListTest.cs
@@ -49,7 +49,7 @@ namespace MailChimp.Net.Tests
             var list = await this._mailChimpManager.Configure(new MailChimpConfiguration
             {
                 Limit = 10
-            }).Lists.AddOrUpdateAsync(this.MailChimpList).ConfigureAwait(false);
+            }).Lists.AddOrUpdateAsync(this.GetMailChimpList()).ConfigureAwait(false);
 
             var allLists = await this._mailChimpManager.Lists.GetAllAsync().ConfigureAwait(false);
             Assert.IsTrue(allLists.Count() > 0);

--- a/MailChimp.Net.Tests/ListWebhookTests.cs
+++ b/MailChimp.Net.Tests/ListWebhookTests.cs
@@ -1,0 +1,61 @@
+﻿using System.Threading.Tasks;
+using FluentAssertions;
+using MailChimp.Net.Core;
+using MailChimp.Net.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MailChimp.Net.Tests
+{
+    [TestClass]
+    public class ListWebhookTests : MailChimpTest
+    {
+        private const string ListName = "TestListWebhooks";
+        private string _listId = string.Empty;
+
+        internal override async Task RunBeforeTestFixture()
+        {
+            await ClearLists(ListName);
+
+            var list = await _mailChimpManager.Lists.AddOrUpdateAsync(GetMailChimpList(ListName));
+            _listId = list.Id;
+        }
+
+        [TestMethod]
+        public async Task Should_Create_Webhook()
+        {
+            // Arrange
+            var webhook = new WebHook
+            {
+                Event = new Event
+                {
+                    Campaign = true,
+                    Cleaned = true,
+                    Profile = true,
+                    Subscribe = true,
+                    Unsubscribe = true,
+                    Upemail = true
+                },
+                Source = new Source
+                {
+                    Admin = true,
+                    Api = true,
+                    User = true
+                },
+                Url = "www.google.com"
+            };
+
+            // Act
+            var response = await _mailChimpManager.WebHooks.AddAsync(_listId, webhook);
+            var existingWebhook = await _mailChimpManager.WebHooks.GetAsync(_listId, response.Id);
+
+            // Assert
+            response.Id.Should().NotBeEmpty();
+            response.ListId.Should().Be(_listId);
+            response.Links.Should().NotBeEmpty();
+            response.ShouldBeEquivalentTo(webhook,
+                o => o.Excluding(i => i.Id).Excluding(i => i.ListId).Excluding(i => i.Links));
+
+            existingWebhook.Should().NotBeNull();
+        }
+    }
+}

--- a/MailChimp.Net.Tests/MailChimp.Net.Tests.csproj
+++ b/MailChimp.Net.Tests/MailChimp.Net.Tests.csproj
@@ -35,7 +35,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FluentAssertions, Version=4.15.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.15.0\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.15.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.15.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -58,6 +68,7 @@
     <Compile Include="ListMemberTest.cs" />
     <Compile Include="AuthorizedAppTest.cs" />
     <Compile Include="ListTest.cs" />
+    <Compile Include="ListWebhookTests.cs" />
     <Compile Include="MailChimpTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -69,6 +80,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/MailChimp.Net.Tests/MailChimp.Net.Tests.csproj
+++ b/MailChimp.Net.Tests/MailChimp.Net.Tests.csproj
@@ -51,12 +51,12 @@
   </Choose>
   <ItemGroup>
     <Compile Include="ECommerceLogicTest.cs" />
-    <Compile Include="AuthorizedAppTest.cs" />
+    <Compile Include="ApiTest.cs" />
     <Compile Include="ConversationTest.cs" />
     <Compile Include="CampaignTest.cs" />
     <Compile Include="FeedbackTest.cs" />
     <Compile Include="ListMemberTest.cs" />
-    <Compile Include="ApiTest.cs" />
+    <Compile Include="AuthorizedAppTest.cs" />
     <Compile Include="ListTest.cs" />
     <Compile Include="MailChimpTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/MailChimp.Net.Tests/packages.config
+++ b/MailChimp.Net.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FluentAssertions" version="4.15.0" targetFramework="net46" />
+</packages>

--- a/MailChimp.Net/Interfaces/IWebHookLogic.cs
+++ b/MailChimp.Net/Interfaces/IWebHookLogic.cs
@@ -26,10 +26,13 @@ namespace MailChimp.Net.Interfaces
         /// <param name="listId">
         /// The list id.
         /// </param>
+        /// <param name="webhook">
+        /// Webhook.
+        /// </param>
         /// <returns>
         /// The <see cref="Task"/>.
         /// </returns>
-        Task<WebHook> AddAsync(string listId);
+        Task<WebHook> AddAsync(string listId, WebHook webhook);
 
         /// <summary>
         /// The delete async.

--- a/MailChimp.Net/Logic/WebHookLogic.cs
+++ b/MailChimp.Net/Logic/WebHookLogic.cs
@@ -48,14 +48,17 @@ namespace MailChimp.Net.Logic
         /// <param name="listId">
         /// The list id.
         /// </param>
+        /// <param name="webhook">
+        /// Webhook.
+        /// </param>
         /// <returns>
         /// The <see cref="Task"/>.
         /// </returns>
-        public async Task<WebHook> AddAsync(string listId)
+        public async Task<WebHook> AddAsync(string listId, WebHook webhook)
         {
             using (var client = this.CreateMailClient(string.Format(BaseUrl, listId)))
             {
-                var response = await client.PostAsync(string.Empty, null).ConfigureAwait(false);
+                var response = await client.PostAsJsonAsync(string.Empty, webhook).ConfigureAwait(false);
                 await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
 
                 var webHookResponse = await response.Content.ReadAsAsync<WebHook>().ConfigureAwait(false);

--- a/MailChimp.Net/MailChimp.Net.csproj
+++ b/MailChimp.Net/MailChimp.Net.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Interfaces\IECommerceCartLogic.cs" />
     <Compile Include="Logic\ECommerceProductVarianceLogic.cs" />
     <Compile Include="Models\Address.cs" />
+    <Compile Include="Models\ApiContact.cs" />
     <Compile Include="Models\AutomationStatus.cs" />
     <Compile Include="Models\BatchDelivery.cs" />
     <Compile Include="Models\CampaignAction.cs" />

--- a/MailChimp.Net/Models/ApiContact.cs
+++ b/MailChimp.Net/Models/ApiContact.cs
@@ -1,0 +1,58 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ApiInfo.cs" company="Brandon Seydel">
+//   N/A
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+
+namespace MailChimp.Net.Models
+{
+    /// <summary>
+    /// The contact.
+    /// </summary>
+    public class ApiContact
+    {
+        /// <summary>
+        /// Gets or sets the company.
+        /// </summary>
+        [JsonProperty("company")]
+        public string Company { get; set; }
+
+        /// <summary>
+        /// Gets or sets the address 1.
+        /// </summary>
+        [JsonProperty("addr1")]
+        public string Address1 { get; set; }
+
+        /// <summary>
+        /// Gets or sets the address 2.
+        /// </summary>
+        [JsonProperty("addr2")]
+        public string Address2 { get; set; }
+
+        /// <summary>
+        /// Gets or sets the city.
+        /// </summary>
+        [JsonProperty("city")]
+        public string City { get; set; }
+
+        /// <summary>
+        /// Gets or sets the state.
+        /// </summary>
+        [JsonProperty("state")]
+        public string State { get; set; }
+
+        /// <summary>
+        /// Gets or sets the zip.
+        /// </summary>
+        [JsonProperty("zip")]
+        public string Zip { get; set; }
+
+        /// <summary>
+        /// Gets or sets the country.
+        /// </summary>
+        [JsonProperty("country")]
+        public string Country { get; set; }
+    }
+}

--- a/MailChimp.Net/Models/ApiInfo.cs
+++ b/MailChimp.Net/Models/ApiInfo.cs
@@ -29,7 +29,7 @@ namespace MailChimp.Net.Models
         /// Gets or sets the contact.
         /// </summary>
         [JsonProperty("contact")]
-        public Contact Contact { get; set; }
+        public ApiContact Contact { get; set; }
 
         /// <summary>
         /// Gets or sets the last login.


### PR DESCRIPTION
* introduce new contact class for API resource with valid **addr1** and **addr2** json properties. 
* fix unit tests names.
http://developer.mailchimp.com/documentation/mailchimp/reference/root/#read-get_root

* add possibility to add new webhook.
* exclude unit tests assembly folder from .gitignore