### PR TITLE
Adding unit test coverage for campaign logic

### DIFF
--- a/MailChimp.Net.Tests/CampaignTest.cs
+++ b/MailChimp.Net.Tests/CampaignTest.cs
@@ -20,7 +20,88 @@ namespace MailChimp.Net.Tests
     public class CampaignTest : MailChimpTest
     {
         /// <summary>
-        /// The should_ get_ one_ campain_ id_ and_ get_ campaign.
+        /// The should_ create_ campaign_
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Task Should_Add_Campaign()
+        {
+            var campaign = await this._mailChimpManager.Campaigns.AddAsync(new Campaign
+            {
+                Settings = new Setting
+                {
+                    ReplyTo = "test@test.com",
+                    Title = "Get Rich or Die Trying To Add Campaigns",
+                    FromName = "AddCampaign",
+                    SubjectLine = "TestingAddCampaign"
+                },
+                Type = CampaignType.Plaintext
+            }).ConfigureAwait(false);
+
+            Assert.IsNotNull(campaign);
+        }
+        
+        /// <summary>
+        /// The should_ update_ campaign_
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Task Should_Update_Campaign()
+        {
+            var campaigns = await this._mailChimpManager.Campaigns.GetAll(new CampaignRequest { Limit = 1 });
+            var campaign = campaigns.FirstOrDefault();
+            if (campaign != null)
+            {
+                var updated = await this._mailChimpManager.Campaigns.UpdateAsync(campaign.Id, new Campaign
+                {
+                    Settings = new Setting
+                    {
+                        ReplyTo = "updatedtest@updatedtest.com",
+                        Title = "Updated from Unit Test",
+                        FromName = "Updated Tester",
+                        SubjectLine = "Updated Test"
+                    },
+                    Type = CampaignType.Plaintext
+                }).ConfigureAwait(false);
+                Assert.IsNotNull(updated);
+            }
+        }
+        
+        /// <summary>
+        /// The should_ replicate_ campaign_
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Task Should_Replicate_Campaign()
+        {
+            var campaigns = await this._mailChimpManager.Campaigns.GetAllAsync();
+            var campaign = campaigns.FirstOrDefault();
+            if (campaign != null)
+            {
+                var response = await this._mailChimpManager.Campaigns.ReplicateCampaignAsync(campaign.Id).ConfigureAwait(false);
+                Assert.IsNotNull(response);
+            }
+        }
+
+        /// <summary>
+        /// The should_ delete_ campaign_
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Task Should_Delete_Campaign()
+        {
+            var campaigns = await this._mailChimpManager.Campaigns.GetAllAsync();
+            var campaign = campaigns.FirstOrDefault();
+            if (campaign != null)
+            {
+                await this._mailChimpManager.Campaigns.DeleteAsync(campaign.Id).ConfigureAwait(false);
+                var campaignsnow = await this._mailChimpManager.Campaigns.GetAllAsync();
+                Assert.AreNotEqual(campaigns.Count(), campaignsnow.Count());
+            }
+        }
+
+        /// <summary>
+        /// The should_ get_ one_ campaign_ id_ and_ get_ campaign.
         /// </summary>
         /// <returns>
         /// The <see cref="Task"/>.


### PR DESCRIPTION
Another commit for [Issue #8](https://github.com/brandonseydel/MailChimp.Net/issues/8) to add unit test coverage. This adds a few more test methods for the campaign logic.