### PR TITLE
Change default update status to be Undefined

### DIFF
--- a/MailChimp.Net/Models/Member.cs
+++ b/MailChimp.Net/Models/Member.cs
@@ -22,7 +22,7 @@ namespace MailChimp.Net.Models
             this.MergeFields = new Dictionary<string, object>();
             this.Links = new List<Link>();
             this.Interests = new Dictionary<string, bool>();
-            this.Status = Status.Pending;
+            this.Status = Status.Undefined;
             this.StatusIfNew = Status.Pending;            
         }
 
@@ -123,7 +123,7 @@ namespace MailChimp.Net.Models
 		public MemberStats Stats { get; set; }
 
         /// <summary>
-        /// Sets the member's status unless they are new.  Then you need to use the <see cref="StatusIfNew"/> property.  Default value is <see cref="Status.Pending"/>  
+        /// Sets the member's status unless they are new.  Then you need to use the <see cref="StatusIfNew"/> property.  Default value is <see cref="Status.Undefined"/>  
         /// </summary>
 		[JsonProperty("status")]
 		[JsonConverter(typeof(StringEnumDescriptionConverter))]


### PR DESCRIPTION
When updating a `Member` having the `Status` set to `Pending` will effectively remove these members from the list. This is potentially dangerous operation.

The default should be `Undefined` which will then do nothing when updating.

Fixes #158