### PR TITLE
fixing search-members when using list_id parameter

### DIFF
--- a/MailChimp.Net/Core/Requests/MemberSearchRequest.cs
+++ b/MailChimp.Net/Core/Requests/MemberSearchRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace MailChimp.Net.Core
+namespace MailChimp.Net.Core
 {
     public class MemberSearchRequest : BaseRequest
     {
@@ -9,6 +9,7 @@
         /// <summary>
         /// The unique id for the list.
         /// </summary>
+        [QueryString("list_id")]
         public string ListId { get; set; }
         /// <summary>
         /// The number of instances to skip from the beginning of the collection. Default value is 0.


### PR DESCRIPTION
The request sent to the MailChimp API when searching for members of a specific list is being called like so:
GET /3.0/search-members?query=email@test.com&listid=xxxxxxxxxx&offset=0 HTTP/1.1

Instead, it should be getting called like this:
GET /3.0/search-members?query=email@test.com&list_id=xxxxxxxxxx&offset=0 HTTP/1.1

I believe the following change should be made in MemberSearchRequest.cs:

```C#
[QueryString("list_id")]
public string ListId { get; set; }