### PR TITLE
Added long_archive_url to campaign object

### DIFF
--- a/MailChimp.Net/Models/Campaign.cs
+++ b/MailChimp.Net/Models/Campaign.cs
@@ -22,6 +22,12 @@ namespace MailChimp.Net.Models
         public string ArchiveUrl { get; set; }
 
         /// <summary>
+        /// Gets or sets the archive url.
+        /// </summary>
+        [JsonProperty("long_archive_url")]
+        public string LongArchiveUrl { get; set; }
+
+        /// <summary>
         /// Gets or sets the content type.
         /// </summary>
         [JsonProperty("content_type")]

--- a/MailChimp.Net/Models/Campaign.cs
+++ b/MailChimp.Net/Models/Campaign.cs
@@ -22,7 +22,7 @@ namespace MailChimp.Net.Models
         public string ArchiveUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets the archive url.
+        /// Gets or sets the long archive url.
         /// </summary>
         [JsonProperty("long_archive_url")]
         public string LongArchiveUrl { get; set; }


### PR DESCRIPTION
This is needed if you want to concatenate the member unique id to the URL in order to create a link with merging of variables enabled.