### PR TITLE
fixes endpoint for retrieving automation emails

### DIFF
--- a/MailChimp.Net/Logic/AutomationEmailLogic.cs
+++ b/MailChimp.Net/Logic/AutomationEmailLogic.cs
@@ -67,7 +67,7 @@ namespace MailChimp.Net.Logic
         {
             using (var client = CreateMailClient("automations"))
             {
-                var response = await client.GetAsync($"{workflowId}/emails").ConfigureAwait(false);
+                var response = await client.GetAsync($"automations/{workflowId}/emails").ConfigureAwait(false);
                 await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
                 var automationResponse = await response.Content.ReadAsAsync<AutomationEmailResponse>().ConfigureAwait(false);
                 return automationResponse;


### PR DESCRIPTION
Tried retrieving automation emails, but got 404 error.
Documentation page, where I got the correct endpoint from: https://developer.mailchimp.com/documentation/mailchimp/reference/automations/emails/