### PR TITLE
Adding Merge_Fields to SentTo

### DIFF
--- a/MailChimp.Net/Models/SentTo.cs
+++ b/MailChimp.Net/Models/SentTo.cs
@@ -1,10 +1,11 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SentTo.cs" company="Brandon Seydel">
 //   N/A
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace MailChimp.Net.Models
@@ -73,5 +74,11 @@ namespace MailChimp.Net.Models
         /// </summary>
         [JsonProperty("status")]
         public string Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the merge fields.
+        /// </summary>
+        [JsonProperty("merge_fields")]
+        public List<SentToMergeFields> MergeFields { get; set; }
     }
 }

--- a/MailChimp.Net/Models/SentToMergeField.cs
+++ b/MailChimp.Net/Models/SentToMergeField.cs
@@ -1,0 +1,23 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SentTo.cs" company="Brandon Seydel">
+//   N/A
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System;
+using Newtonsoft.Json;
+
+namespace MailChimp.Net.Models
+{
+    /// <summary>
+    /// The sent to merge fields
+    /// </summary>
+    public class SentToMergeFields
+    {
+        /// <summary>
+        /// Gets or sets the absplit group.
+        /// </summary>
+        public string FieldName { get; set; }
+        public string FieldValue { get; set; }
+    }
+}

--- a/MailChimp.Net/Models/SentToMergeField.cs
+++ b/MailChimp.Net/Models/SentToMergeField.cs
@@ -15,7 +15,7 @@ namespace MailChimp.Net.Models
     public class SentToMergeFields
     {
         /// <summary>
-        /// Gets or sets the absplit group.
+        /// Gets or sets the merge fields.
         /// </summary>
         public string FieldName { get; set; }
         public string FieldValue { get; set; }


### PR DESCRIPTION
This is my very first Pull Request so apologies if I am doing anything wrong.

I noticed that the Merge_Fields are missing from the SentTo class when using GetSentToRecipientsAsync.

This is what the JSON coming back from the API looks like:

![image](https://user-images.githubusercontent.com/2582681/38257887-15a98a8c-3759-11e8-89b8-76a97439d17a.png)

I have added a new class called "SentToMergeFields" and added MergeFields to the SentTo class.

Please feel free to amend as necessary
