### PR TITLE
Mailchimp.net 298

### DIFF
--- a/MailChimp.Net/Interfaces/IMemberLogic.cs
+++ b/MailChimp.Net/Interfaces/IMemberLogic.cs
@@ -89,7 +89,7 @@ namespace MailChimp.Net.Interfaces
 		/// <param name="listId"></param>
 		/// <param name="memberRequest"></param>
 		/// <returns></returns>
-        Task<int> GetTotalItemsByRequest(string listId, MemberRequest memberRequest)
+        Task<int> GetTotalItemsByRequest(string listId, MemberRequest memberRequest);
 
         /// <summary>
         /// The get async.

--- a/MailChimp.Net/Interfaces/IMemberLogic.cs
+++ b/MailChimp.Net/Interfaces/IMemberLogic.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IMemberLogic.cs" company="Brandon Seydel">
 //   N/A
 // </copyright>
@@ -83,20 +83,28 @@ namespace MailChimp.Net.Interfaces
 		/// <returns></returns>
 		Task<int> GetTotalItems(string listId, Status? status);
 
-		/// <summary>
-		/// The get async.
+        /// <summary>
+		/// Get the total number of members in a list based on a MemberRequest model
 		/// </summary>
-		/// <param name="listId">
-		/// The list id.
-		/// </param>
-		/// <param name="emailAddressOrHash">
-		/// The email address.
-		/// </param>
-		/// <param name="request"></param>
-		/// <returns>
-		/// The <see cref="Task"/>.
-		/// </returns>
-		Task<Member> GetAsync(string listId, string emailAddressOrHash, BaseRequest request = null);
+		/// <param name="listId"></param>
+		/// <param name="memberRequest"></param>
+		/// <returns></returns>
+        Task<int> GetTotalItemsByRequest(string listId, MemberRequest memberRequest)
+
+        /// <summary>
+        /// The get async.
+        /// </summary>
+        /// <param name="listId">
+        /// The list id.
+        /// </param>
+        /// <param name="emailAddressOrHash">
+        /// The email address.
+        /// </param>
+        /// <param name="request"></param>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        Task<Member> GetAsync(string listId, string emailAddressOrHash, BaseRequest request = null);
 
 		/// <summary>
 		/// The check if exists async.

--- a/MailChimp.Net/Logic/MemberLogic.cs
+++ b/MailChimp.Net/Logic/MemberLogic.cs
@@ -272,6 +272,38 @@ namespace MailChimp.Net.Logic
         }
 
         /// <summary>
+        /// Get the total number of members in the list based on a full member request
+        /// </summary>
+        /// <param name="listId"></param>
+        /// <param name="memberRequest"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"><paramref>
+        ///         <name>uriString</name>
+        ///     </paramref>
+        ///     is null. </exception>
+        /// <exception cref="MailChimpException">
+        /// Custom Mail Chimp Exception
+        /// </exception>
+        /// <exception cref="UriFormatException">In the .NET for Windows Store apps or the Portable Class Library, catch the base class exception, <see cref="T:System.FormatException" />, instead.<paramref name="uriString" /> is empty.-or- The scheme specified in <paramref name="uriString" /> is not correctly formed. See <see cref="M:System.Uri.CheckSchemeName(System.String)" />.-or- <paramref name="uriString" /> contains too many slashes.-or- The password specified in <paramref name="uriString" /> is not valid.-or- The host name specified in <paramref name="uriString" /> is not valid.-or- The file name specified in <paramref name="uriString" /> is not valid. -or- The user name specified in <paramref name="uriString" /> is not valid.-or- The host or authority name specified in <paramref name="uriString" /> cannot be terminated by backslashes.-or- The port number specified in <paramref name="uriString" /> is not valid or cannot be parsed.-or- The length of <paramref name="uriString" /> exceeds 65519 characters.-or- The length of the scheme specified in <paramref name="uriString" /> exceeds 1023 characters.-or- There is an invalid character sequence in <paramref name="uriString" />.-or- The MS-DOS path specified in <paramref name="uriString" /> must start with c:\\.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="P:System.Text.StringBuilder.MaxCapacity" />. </exception>
+        /// <exception cref="NotSupportedException"><paramref name="element" /> is not a constructor, method, property, event, type, or field. </exception>
+        /// <exception cref="InvalidOperationException">This member belongs to a type that is loaded into the reflection-only context. See How to: Load Assemblies into the Reflection-Only Context.</exception>
+        /// <exception cref="TypeLoadException">A custom attribute type cannot be loaded. </exception>
+        public async Task<int> GetTotalItemsByRequest(string listId, MemberRequest memberRequest)
+        {
+            using (var client = CreateMailClient($"{BaseUrl}/"))
+            {
+                memberRequest.FieldsToInclude = "total_items";                
+
+                var response = await client.GetAsync($"{listId}/members{memberRequest.ToQueryString()}").ConfigureAwait(false);
+                await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
+
+                var listResponse = await response.Content.ReadAsAsync<MemberResponse>().ConfigureAwait(false);
+                return listResponse.TotalItems;
+            }
+        }
+
+        /// <summary>
         /// The get async.
         /// </summary>
         /// <param name="listId">


### PR DESCRIPTION
This pull request is based on Issue 298, Add a new MemberLogic.cs function to get total items based on a full member request.

When attempting to download a list members based on a member request, it is important to know how many members there are in the request in case you need to download more than the 1000 limit.  Adding this call allow a program to know how many members it needs download per request.  