### PR TITLE
How to get Open Details brandonseydel/MailChimp.Net#278

### DIFF
--- a/MailChimp.Net/Core/Requests/CampaignOpenReportRequest.cs
+++ b/MailChimp.Net/Core/Requests/CampaignOpenReportRequest.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace MailChimp.Net.Core
+{
+    public class CampaignOpenReportRequest : QueryableBaseRequest
+    {
+        [QueryString("since")]
+        public DateTime? Since { get; set; }
+    }
+}

--- a/MailChimp.Net/Core/Responses/CampaignOpenReportResponse.cs
+++ b/MailChimp.Net/Core/Responses/CampaignOpenReportResponse.cs
@@ -1,0 +1,46 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CampaignOpen.cs" company="Brandon Seydel">
+//   N/A
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+using MailChimp.Net.Models;
+
+using Newtonsoft.Json;
+
+namespace MailChimp.Net.Core
+{
+    /// <summary>
+    /// The campaign open report.
+    /// </summary>
+    public class CampaignOpenReportResponse : BaseResponse
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CampaignOpenReportResponse"/> class.
+        /// </summary>
+        public CampaignOpenReportResponse()
+        {
+            Members = new HashSet<Open>();
+        }
+
+        /// <summary>
+        /// Gets or sets the members.
+        /// </summary>
+        [JsonProperty("members")]
+        public HashSet<Open> Members { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total opens.
+        /// </summary>
+        [JsonProperty("total_opens")]
+        public int TotalOpens { get; set; }
+
+        /// <summary>
+        /// Gets or sets the campaign id.
+        /// </summary>
+        [JsonProperty("campaign_id")]
+        public string CampaignId { get; set; }
+    }
+}

--- a/MailChimp.Net/Interfaces/IReportLogic.cs
+++ b/MailChimp.Net/Interfaces/IReportLogic.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IReportLogic.cs" company="Brandon Seydel">
 //   N/A
 // </copyright>
@@ -22,6 +22,8 @@ namespace MailChimp.Net.Interfaces
         Task<SentToResponse> GetSentToRecipientsResponseAsync(string campaignId, QueryableBaseRequest request = null);
         Task<IEnumerable<Report>> GetAllReportsAsync(ReportRequest request = null);
         Task<IEnumerable<Advice>> GetCampaignAdviceAsync(string campaignId, BaseRequest request = null);
+        Task<IEnumerable<Open>> GetCampaignOpenReportAsync(string campaignId, QueryableBaseRequest request = null);
+        Task<int> GetCampaignOpenReportCountAsync(string campaignId, QueryableBaseRequest request = null);
         Task<IEnumerable<UrlClicked>> GetClickReportAsync(string campaignId, QueryableBaseRequest request = null);
         Task<UrlClicked> GetClickReportDetailsAsync(string campaignId, string linkId, BaseRequest request = null);
         Task<ClickMember> GetClickReportMemberAsync(string campaignId, string linkId, string emailAddressOrHash, BaseRequest request = null);
@@ -39,5 +41,6 @@ namespace MailChimp.Net.Interfaces
         Task<IEnumerable<Report>> GetSubReportAsync(string campaignId, BaseRequest request = null);
         Task<Unsubscribe> GetUnsubscriberAsync(string campaignId, string emailAddressOrHash, BaseRequest request = null);
         Task<IEnumerable<Unsubscribe>> GetUnsubscribesAsync(string campaignId, QueryableBaseRequest request = null);
+        Task<int> GetUnsubscribesCountAsync(string campaignId, QueryableBaseRequest request = null);
     }
 }

--- a/MailChimp.Net/Logic/ReportLogic.cs
+++ b/MailChimp.Net/Logic/ReportLogic.cs
@@ -160,6 +160,89 @@ namespace MailChimp.Net.Logic
         }
 
         /// <summary>
+        /// The get campaign open report async.
+        /// </summary>
+        /// <param name="request">
+        /// The request.
+        /// </param>
+        /// <param name="campaignId">
+        /// The campaign id.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref>
+        ///         <name>uriString</name>
+        ///     </paramref>
+        ///     is null. </exception>
+        /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="P:System.Text.StringBuilder.MaxCapacity" />. </exception>
+        /// <exception cref="UriFormatException">In the .NET for Windows Store apps or the Portable Class Library, catch the base class exception, <see cref="T:System.FormatException" />, instead.<paramref name="uriString" /> is empty.-or- The scheme specified in <paramref name="uriString" /> is not correctly formed. See <see cref="M:System.Uri.CheckSchemeName(System.String)" />.-or- <paramref name="uriString" /> contains too many slashes.-or- The password specified in <paramref name="uriString" /> is not valid.-or- The host name specified in <paramref name="uriString" /> is not valid.-or- The file name specified in <paramref name="uriString" /> is not valid. -or- The user name specified in <paramref name="uriString" /> is not valid.-or- The host or authority name specified in <paramref name="uriString" /> cannot be terminated by backslashes.-or- The port number specified in <paramref name="uriString" /> is not valid or cannot be parsed.-or- The length of <paramref name="uriString" /> exceeds 65519 characters.-or- The length of the scheme specified in <paramref name="uriString" /> exceeds 1023 characters.-or- There is an invalid character sequence in <paramref name="uriString" />.-or- The MS-DOS path specified in <paramref name="uriString" /> must start with c:\\.</exception>
+        /// <exception cref="NotSupportedException"><paramref name="element" /> is not a constructor, method, property, event, type, or field. </exception>
+        /// <exception cref="MailChimpException">
+        /// Custom Mail Chimp Exception
+        /// </exception>
+        /// <exception cref="TypeLoadException">A custom attribute type cannot be loaded. </exception>
+        public async Task<IEnumerable<Open>> GetCampaignOpenReportAsync(string campaignId, QueryableBaseRequest request = null)
+        {
+            var campaignOpenReport = await GetCampaignOpenReportResponseAsync(campaignId, request).ConfigureAwait(false);
+            return campaignOpenReport.Members;
+        }
+
+        /// <summary>
+        /// The get campaign open report async.
+        /// </summary>
+        /// <param name="request">
+        /// The request.
+        /// </param>
+        /// <param name="campaignId">
+        /// The campaign id.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref>
+        ///         <name>uriString</name>
+        ///     </paramref>
+        ///     is null. </exception>
+        /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="P:System.Text.StringBuilder.MaxCapacity" />. </exception>
+        /// <exception cref="UriFormatException">In the .NET for Windows Store apps or the Portable Class Library, catch the base class exception, <see cref="T:System.FormatException" />, instead.<paramref name="uriString" /> is empty.-or- The scheme specified in <paramref name="uriString" /> is not correctly formed. See <see cref="M:System.Uri.CheckSchemeName(System.String)" />.-or- <paramref name="uriString" /> contains too many slashes.-or- The password specified in <paramref name="uriString" /> is not valid.-or- The host name specified in <paramref name="uriString" /> is not valid.-or- The file name specified in <paramref name="uriString" /> is not valid. -or- The user name specified in <paramref name="uriString" /> is not valid.-or- The host or authority name specified in <paramref name="uriString" /> cannot be terminated by backslashes.-or- The port number specified in <paramref name="uriString" /> is not valid or cannot be parsed.-or- The length of <paramref name="uriString" /> exceeds 65519 characters.-or- The length of the scheme specified in <paramref name="uriString" /> exceeds 1023 characters.-or- There is an invalid character sequence in <paramref name="uriString" />.-or- The MS-DOS path specified in <paramref name="uriString" /> must start with c:\\.</exception>
+        /// <exception cref="NotSupportedException"><paramref name="element" /> is not a constructor, method, property, event, type, or field. </exception>
+        /// <exception cref="MailChimpException">
+        /// Custom Mail Chimp Exception
+        /// </exception>
+        /// <exception cref="TypeLoadException">A custom attribute type cannot be loaded. </exception>
+        public async Task<int> GetCampaignOpenReportCountAsync(string campaignId, QueryableBaseRequest request = null)
+        {
+            // Limit the response to the total only with the min query limit
+            request = request ?? new CampaignOpenReportRequest();
+            request.Limit = 1;
+            request.FieldsToExclude = "_links,campaign_id,members,total_opens";
+
+            var campaignOpenReport = await GetCampaignOpenReportResponseAsync(campaignId, request).ConfigureAwait(false);
+            return campaignOpenReport.TotalItems;
+        }
+
+
+
+        private async Task<CampaignOpenReportResponse> GetCampaignOpenReportResponseAsync(
+            string campaignId,
+            QueryableBaseRequest request = null)
+        {
+            request = request ?? new QueryableBaseRequest
+            {
+                Limit = _limit
+            };
+
+            using (var client = CreateMailClient("reports/"))
+            {
+                var response = await client.GetAsync($"{campaignId}/open-details{request.ToQueryString()}").ConfigureAwait(false);
+                await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
+                var reportResponse = await response.Content.ReadAsAsync<CampaignOpenReportResponse>().ConfigureAwait(false);
+                return reportResponse;
+            }
+        }
+
+        /// <summary>
         /// The get click report async.
         /// </summary>
         /// <param name="request">
@@ -832,6 +915,50 @@ namespace MailChimp.Net.Logic
             string campaignId,
             QueryableBaseRequest request = null)
         {
+            var reportResponse = await GetUnsubscribesReportResponseAsync(campaignId, request).ConfigureAwait(false);
+            return reportResponse.Unsubscribes;
+        }
+
+        /// <summary>
+        /// The get unsubscribes async.
+        /// </summary>
+        /// <param name="request">
+        /// The request.
+        /// </param>
+        /// <param name="campaignId">
+        /// The campaign id.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref>
+        ///         <name>uriString</name>
+        ///     </paramref>
+        ///     is null. </exception>
+        /// <exception cref="UriFormatException">In the .NET for Windows Store apps or the Portable Class Library, catch the base class exception, <see cref="T:System.FormatException" />, instead.<paramref name="uriString" /> is empty.-or- The scheme specified in <paramref name="uriString" /> is not correctly formed. See <see cref="M:System.Uri.CheckSchemeName(System.String)" />.-or- <paramref name="uriString" /> contains too many slashes.-or- The password specified in <paramref name="uriString" /> is not valid.-or- The host name specified in <paramref name="uriString" /> is not valid.-or- The file name specified in <paramref name="uriString" /> is not valid. -or- The user name specified in <paramref name="uriString" /> is not valid.-or- The host or authority name specified in <paramref name="uriString" /> cannot be terminated by backslashes.-or- The port number specified in <paramref name="uriString" /> is not valid or cannot be parsed.-or- The length of <paramref name="uriString" /> exceeds 65519 characters.-or- The length of the scheme specified in <paramref name="uriString" /> exceeds 1023 characters.-or- There is an invalid character sequence in <paramref name="uriString" />.-or- The MS-DOS path specified in <paramref name="uriString" /> must start with c:\\.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="P:System.Text.StringBuilder.MaxCapacity" />. </exception>
+        /// <exception cref="MailChimpException">
+        /// Custom Mail Chimp Exception
+        /// </exception>
+        /// <exception cref="NotSupportedException"><paramref name="element" /> is not a constructor, method, property, event, type, or field. </exception>
+        /// <exception cref="TypeLoadException">A custom attribute type cannot be loaded. </exception>
+        public async Task<int> GetUnsubscribesCountAsync(
+            string campaignId,
+            QueryableBaseRequest request = null)
+        {
+            // Limit the response to the total only with the min query limit
+            request = request ?? new QueryableBaseRequest();
+            request.Limit = 1;
+            request.FieldsToExclude = "_links,campaign_id,unsubscribes";
+
+            var reportResponse = await GetUnsubscribesReportResponseAsync(campaignId, request).ConfigureAwait(false);
+            return reportResponse.TotalItems;
+        }
+
+        private async Task<UnsubscribeReportResponse> GetUnsubscribesReportResponseAsync(
+            string campaignId,
+            QueryableBaseRequest request = null)
+        {
             request = request ?? new QueryableBaseRequest
             {
                 Limit = _limit
@@ -842,7 +969,7 @@ namespace MailChimp.Net.Logic
                 var response = await client.GetAsync($"{campaignId}/unsubscribed{request.ToQueryString()}").ConfigureAwait(false);
                 await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
                 var reportResponse = await response.Content.ReadAsAsync<UnsubscribeReportResponse>().ConfigureAwait(false);
-                return reportResponse.Unsubscribes;
+                return reportResponse;
             }
         }
     }

--- a/MailChimp.Net/Models/Open.cs
+++ b/MailChimp.Net/Models/Open.cs
@@ -1,0 +1,74 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="Open.cs" company="Brandon Seydel">
+//   N/A
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+
+using System;
+using System.Collections.Generic;
+
+namespace MailChimp.Net.Models
+{
+    /// <summary>
+    /// The Open.
+    /// </summary>
+    public class Open
+    {
+        /// <summary>
+        /// Gets or sets the campaign id.
+        /// </summary>
+        [JsonProperty("campaign_id")]
+        public string CampaignId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list id.
+        /// </summary>
+        [JsonProperty("list_id")]
+        public string ListId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the email id.
+        /// </summary>
+        [JsonProperty("email_id")]
+        public string EmailId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the email address.
+        /// </summary>
+        [JsonProperty("email_address")]
+        public string EmailAddress { get; set; }
+
+        /// <summary>
+        /// Gets or sets the merge fields.
+        /// </summary>
+        [JsonProperty("merge_fields")]
+        public Dictionary<string, object> MergeFields { get; set; }
+
+        /// <summary>
+        /// Gets or sets the vip.
+        /// </summary>
+        [JsonProperty("vip")]
+        public bool VIP { get; set; }
+
+        /// <summary>
+        /// Gets or sets the clicks.
+        /// </summary>
+        [JsonProperty("opens_count")]
+        public int OpensCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the clicks.
+        /// </summary>
+        [JsonProperty("opens")]
+        public TimeStamp[] Opens  { get; set; }
+
+        /// <summary>
+        /// Gets or sets the links.
+        /// </summary>
+        [JsonProperty("_links")]
+        public IEnumerable<Link> Links { get; set; }
+
+    }
+}

--- a/MailChimp.Net/Models/TimeStamp.cs
+++ b/MailChimp.Net/Models/TimeStamp.cs
@@ -1,0 +1,26 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TimeStamp.cs" company="Brandon Seydel">
+//   N/A
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+
+using System;
+
+namespace MailChimp.Net.Models
+{
+    /// <summary>
+    /// The TimeStamp.
+    /// </summary>
+    public class TimeStamp
+    {
+
+        /// <summary>
+        /// Gets or sets the Timestamp.
+        /// </summary>
+        [JsonProperty("timestamp")]
+        public DateTime Timestamp { get; set; }
+
+    }
+}


### PR DESCRIPTION
Added count only Report functions for Campaign Open Report and Unsubscribes to streamline polling process.

Implementation of Open Details report. https://developer.mailchimp.com/documentation/mailchimp/reference/reports/open-details/