### PR TITLE
Added Empty enum type to Match model, closes #314

### DIFF
--- a/MailChimp.Net/Models/Match.cs
+++ b/MailChimp.Net/Models/Match.cs
@@ -8,6 +8,8 @@ namespace MailChimp.Net.Models
         [Description("any")]
         Any,
         [Description("all")]
-        All
+        All,
+        [Description("")]
+        Empty
     }
 }


### PR DESCRIPTION
API documentation states that valid values (when returning campaigns for instance) for "campaigns" -> "recipients" -> "segment_opts" -> "match" are "all" and "any", but there are cases where empty string "" is returned. To prevert exception from being thrown, Empty enum type was added to Match model.