### PR TITLE
change Latitude and Longitude to nullable decimal for ecommerce OrderAddress and StoreAddress

### DIFF
--- a/MailChimp.Net/Models/OrderAddress.cs
+++ b/MailChimp.Net/Models/OrderAddress.cs
@@ -17,13 +17,13 @@ namespace MailChimp.Net.Models
         /// Gets or sets the latitude.
         /// </summary>
         [JsonProperty("latitude")]
-        public int Latitude { get; set; }
+        public decimal? Latitude { get; set; }
 
         /// <summary>
         /// Gets or sets the longitude.
         /// </summary>
         [JsonProperty("longitude")]
-        public int Longitude { get; set; }
+        public decimal? Longitude { get; set; }
 
         /// <summary>
         /// Gets or sets the phone number.

--- a/MailChimp.Net/Models/StoreAddress.cs
+++ b/MailChimp.Net/Models/StoreAddress.cs
@@ -11,13 +11,13 @@ namespace MailChimp.Net.Models
         /// Gets or sets the latitude.
         /// </summary>
         [JsonProperty("latitude")]
-        public int Latitude { get; set; }
+        public decimal? Latitude { get; set; }
 
         /// <summary>
         /// Gets or sets the longitude.
         /// </summary>
         [JsonProperty("longitude")]
-        public int Longitude { get; set; }
+        public decimal? Longitude { get; set; }
 
     }
 }


### PR DESCRIPTION
Latitude and Longitude are option so should be nullable, and should be decimal instead of int to accurately store Latitude & Longitude. 