### PR TITLE
represent monetary amounts as decimal and make optional properties nullable

### DIFF
--- a/MailChimp.Net/Models/Cart.cs
+++ b/MailChimp.Net/Models/Cart.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using MailChimp.Net.Core;
@@ -30,10 +30,10 @@ namespace MailChimp.Net.Models
         public CurrencyCode CurrencyCode { get; set; }
 
         [JsonProperty("order_total")]
-        public double OrderTotal { get; set; }
+        public decimal? OrderTotal { get; set; }
 
         [JsonProperty("tax_total")]
-        public double TaxTotal { get; set; }
+        public decimal? TaxTotal { get; set; }
 
         [JsonProperty("lines")]
         public ICollection<Line> Lines { get; set; }

--- a/MailChimp.Net/Models/Customer.cs
+++ b/MailChimp.Net/Models/Customer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -30,10 +30,10 @@ namespace MailChimp.Net.Models
         public string LastName { get; set; }
 
         [JsonProperty("orders_count")]
-        public int OrdersCount { get; set; }
+        public int? OrdersCount { get; set; }
 
         [JsonProperty("total_spent")]
-        public double TotalSpent { get; set; }
+        public decimal? TotalSpent { get; set; }
 
         [JsonProperty("address")]
         public Address Address { get; set; }

--- a/MailChimp.Net/Models/Ecommerce.cs
+++ b/MailChimp.Net/Models/Ecommerce.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace MailChimp.Net.Models
 {
@@ -9,9 +9,9 @@ namespace MailChimp.Net.Models
         public int TotalOrders { get; set; }
 
         [JsonProperty("total_spent")]
-        public double TotalSpent { get; set; }
+        public decimal TotalSpent { get; set; }
 
         [JsonProperty("total_revenue")]
-        public double TotalRevenue { get; set; }
+        public decimal TotalRevenue { get; set; }
     }
 }

--- a/MailChimp.Net/Models/Line.cs
+++ b/MailChimp.Net/Models/Line.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace MailChimp.Net.Models
@@ -30,7 +30,7 @@ namespace MailChimp.Net.Models
         public int Quantity { get; set; }
 
         [JsonProperty("price")]
-        public double Price { get; set; }
+        public decimal Price { get; set; }
 
         [JsonProperty("_links")]
         public IList<Link> Links { get; set; }

--- a/MailChimp.Net/Models/Order.cs
+++ b/MailChimp.Net/Models/Order.cs
@@ -40,19 +40,19 @@ namespace MailChimp.Net.Models
         public CurrencyCode CurrencyCode { get; set; }
 
         [JsonProperty("order_total")]
-        public double OrderTotal { get; set; }
+        public decimal OrderTotal { get; set; }
 
         [JsonProperty("order_url")]
         public string OrderUrl { get; set; }
 
         [JsonProperty("discount_total")]
-        public double DiscountTotal { get; set; }
+        public decimal? DiscountTotal { get; set; }
 
         [JsonProperty("tax_total")]
-        public double TaxTotal { get; set; }
+        public decimal? TaxTotal { get; set; }
 
         [JsonProperty("shipping_total")]
-        public double ShippingTotal { get; set; }
+        public decimal? ShippingTotal { get; set; }
 
         [JsonProperty("tracking_code")]
         public string TrackingCode { get; set; }

--- a/MailChimp.Net/Models/Promo.cs
+++ b/MailChimp.Net/Models/Promo.cs
@@ -8,7 +8,7 @@ namespace MailChimp.Net.Models
         public string Code { get; set; }
 
         [JsonProperty("amount_discounted")]
-        public double AmountDiscounted { get; set; }
+        public decimal AmountDiscounted { get; set; }
 
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/MailChimp.Net/Models/Variant.cs
+++ b/MailChimp.Net/Models/Variant.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -19,10 +19,10 @@ namespace MailChimp.Net.Models
         public string Sku { get; set; }
 
         [JsonProperty("price")]
-        public double Price { get; set; }
+        public decimal? Price { get; set; }
 
         [JsonProperty("inventory_quantity")]
-        public int InventoryQuantity { get; set; }
+        public int? InventoryQuantity { get; set; }
 
         [JsonProperty("image_url")]
         public string ImageUrl { get; set; }


### PR DESCRIPTION
money values should be represented as decimal data type due to inaccuracy of double.
https://stackoverflow.com/questions/1165761/decimal-vs-double-which-one-should-i-use-and-when

also propose switching to nullable types for optional fields so it's possible to not include those fields in serialised json when values are not specifically set.