### PR TITLE
Condition type Aim needs to have its description capitalized

### DIFF
--- a/MailChimp.Net/Models/ConditionType.cs
+++ b/MailChimp.Net/Models/ConditionType.cs
@@ -4,7 +4,7 @@ namespace MailChimp.Net.Models
 {
     public enum ConditionType
     {
-        [Description("aim")]
+        [Description("Aim")]
         Aim,
         [Description("automation")]
         Automation,


### PR DESCRIPTION
solves [issue 324](https://github.com/brandonseydel/MailChimp.Net/issues/324) by ensuring that Aim is sent to MailChimp with a capital letter A in Aim instead of lowercase.

MailChimp's documentation doesn't tell us that it needs to be capitalized, but I've attempted with `aim`, and the call fails.
The call succeeds when the condition type's value is `Aim`.