### PR TITLE
Exception when accesssing Data twice on MailChimpException

### DIFF
--- a/MailChimp.Net.Tests/ExceptionTest.cs
+++ b/MailChimp.Net.Tests/ExceptionTest.cs
@@ -1,0 +1,22 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using MailChimp.Net.Core;
+using MailChimp.Net.Models;
+using Xunit;
+
+namespace MailChimp.Net.Tests
+{
+    public class ExceptionTest : MailChimpTest
+    {
+        [Fact]
+        public void Should_Return_Same_Data_On_Multiple_Calls()
+        {
+            var exception = new MailChimpException(new MailChimpApiError(), new HttpResponseMessage());
+
+            var data1 = exception.Data;
+            var data2 = exception.Data;
+
+            Assert.Equal(data1, data2);
+        }
+    }
+}

--- a/MailChimp.Net/Core/MailChimpException.cs
+++ b/MailChimp.Net/Core/MailChimpException.cs
@@ -42,6 +42,8 @@ namespace MailChimp.Net.Core
             return builder.ToString();
         }
 
+        private IDictionary _data;
+
         public List<MailChimpError> Errors { get; set; }
 
         /// <summary>
@@ -78,6 +80,9 @@ namespace MailChimp.Net.Core
         {
             get
             {
+                if (_data != null)
+                    return _data;
+
                 var data = base.Data;
                 data.Add("detail", Detail);
                 data.Add("title", Title);
@@ -86,7 +91,9 @@ namespace MailChimp.Net.Core
                 data.Add("instance", Instance);
                 data.Add("errors", Errors);
                 data.Add("rawhttpresponsemessage", RawHttpResponseMessage);
-                return data;
+
+                _data = data;
+                return _data;
             }
         }
     }


### PR DESCRIPTION
Hi,

First of all thanks for creating this wrapper - we use it a lot on our solutions.

We started noticing these exceptions (also mentioned here #348) in our logs.
> threw System.ArgumentException: Item has already been added. Key in dictionary: 'detail'  Key being added: 'detail'


So the following change should fix this problem, by only adding properties to the list once. I've also created a unit test.

I'm happy to retrieve any feedback.