### PR TITLE
Rearranged member status enums to fix serialization issues

### DIFF
--- a/MailChimp.Net/Models/Status.cs
+++ b/MailChimp.Net/Models/Status.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Status.cs" company="Brandon Seydel">
 //   N/A
 // </copyright>
@@ -13,6 +13,12 @@ namespace MailChimp.Net.Models
     /// </summary>
     public enum Status
     {
+        /// <summary>
+        /// The undefined.
+        /// </summary>
+        [Description("")]
+        Undefined,
+
         /// <summary>
         /// The subscribed.
         /// </summary>
@@ -39,13 +45,7 @@ namespace MailChimp.Net.Models
 
 
         [Description("transactional")]
-        Transactional,
+        Transactional
         
-        /// <summary>
-        /// The undefined.
-        /// </summary>
-        [Description("")]
-        Undefined
-
     }
 }


### PR DESCRIPTION
By moving `Undefined` in the `Status` enum to the 0 value the `"status_if_new":"subscribed"` is included in the serialization when `serializerSettings.DefaultValueHandling = DefaultValueHandling.Ignore` is specified.
see #393 