### PR TITLE
Fix bug: When using MailChimpManager Members AddOrUpdateAsync method…

### DIFF
--- a/MailChimp.Net/Models/MarketingPermissionText.cs
+++ b/MailChimp.Net/Models/MarketingPermissionText.cs
@@ -17,7 +17,7 @@ namespace MailChimp.Net.Models
     {
         public static Dictionary<string, MarketingPermissionText> GetMarketingPermissions()
         {
-            var dictionary = new Dictionary<string, MarketingPermissionText>();
+            var dictionary = new Dictionary<string, MarketingPermissionText>(StringComparer.CurrentCultureIgnoreCase);
 
             var regex = new Regex(@"
                 (?<=[A-Z])(?=[A-Z][a-z]) |


### PR DESCRIPTION
… with a non empty List<MarketingPermissionText>()   e.g List<MarketingPermissionText>() {MarketingPermissionText.Email, MarketingPermissionText.CustomizedOnlineAdvertising} the library errors with The given key was not present in the dictionary.

When I ran and inspected the code I saw that the 

MarketingPermissionTextHelpers.GetMarketingPermissions() method in MarketingPermissionText.cs creates the following dictionary:

Email, Email
Direct Mail, DirectMail
Customized Online Advertising, CustomizedOnlineAdvertising

However in MemberLogic.cs line 113 when the error occurs the dictionary is called with key
Customized online advertising (note the lower case o and a).  Customized online advertising does not exist in the dictionary but Customized Online Advertising does, i.e. the case of the words is causing the problem.

My fix tells the dictionary to ignore case when using the key and therefore the dictionary thus fixing the problem.