### PR TITLE
Add 2 product tests and fix another - adding/updating product and creating a cart

### DIFF
--- a/MailChimp.Net.Tests/ECommerceLogicTest.cs
+++ b/MailChimp.Net.Tests/ECommerceLogicTest.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MailChimp.Net.Core;
@@ -17,6 +19,42 @@ namespace MailChimp.Net.Tests
     /// </summary>
     public class ECommerceLogicTest : MailChimpTest
     {
+        private const string ListName = "TestListEccommerce";
+        private const string StoreName = "TestStore";
+        private const CurrencyCode Currency = CurrencyCode.GBP;
+        private const decimal TestProductPrice = 1m;
+
+        private string _storeId = string.Empty;
+        private string _customerId = string.Empty;
+        
+
+        internal override async Task RunBeforeTestFixture()
+        {
+            var list = await ClearAndGetNewList();
+            var store = await ClearAndGetNewStore(list.Id);
+            _storeId = store.Id;
+            var customer = await AddCustomerToStore(_storeId);
+            _customerId = customer.Id;
+        }
+
+        [Fact]
+        public async Task Should_Create_Product()
+        {
+            var product = await this.MailChimpManager.ECommerceStores.Products(_storeId).AddAsync(GetTestProduct());
+            Assert.NotNull(product);
+        }
+
+        [Fact]
+        public async Task Should_Update_Product()
+        {    
+            var product = await this.MailChimpManager.ECommerceStores.Products(_storeId).AddAsync(GetTestProduct());
+            var newProductTitle = product.Title + "1";
+            product.Title = newProductTitle;
+            product = await this.MailChimpManager.ECommerceStores.Products(_storeId).UpdateAsync(product.Id, product);
+            Assert.NotNull(product);
+            Assert.Equal(newProductTitle, product.Title);
+        }
+
         /// <summary>
         /// The should_ return_ app_ information.
         /// </summary>
@@ -26,23 +64,83 @@ namespace MailChimp.Net.Tests
         [Fact]
         public async Task Should_Return_App_Information()
         {
-            try
+            var product = await this.MailChimpManager.ECommerceStores.Products(_storeId).AddAsync(GetTestProduct());
+            var variant = product.Variants.FirstOrDefault();        
+
+            var testCart = await this.MailChimpManager.ECommerceStores.Carts(_storeId).AddAsync(new Cart
             {
-                var stores = await this.MailChimpManager.ECommerceStores.GetAllAsync();
-                await Task.WhenAll(stores.Select(x => this.MailChimpManager.ECommerceStores.DeleteAsync(x.Id)));
-                var testStore = await this.MailChimpManager.ECommerceStores.AddAsync(new Store {Name = "TestStore"});
-                var testCart = await this.MailChimpManager.ECommerceStores.Carts(testStore.Id).AddAsync(new Cart
+                Id = "1",
+                Customer = new Customer {Id = _customerId },
+                CurrencyCode = Currency,
+                OrderTotal = TestProductPrice,
+                Lines = new List<Line>()
                 {
-
-
-                });
-                Assert.NotNull(testStore);
-            }
-            catch (MailChimpException)
-            {
-                
-            }
+                    new Line
+                    {
+                        Id="1",
+                        ProductId = product.Id,
+                        ProductVariantId = variant.Id,
+                        Quantity = 1,
+                        Price = (decimal)variant.Price
+                    }
+                }
+            });
+            Assert.NotNull(testCart);
+          
             //await this._mailChimpManager.ECommerceStores.Products("storeId").Variances("productId");
+        }
+
+
+        private async Task<List> ClearAndGetNewList()
+        {
+            await ClearLists().ConfigureAwait(false);
+            return await this.MailChimpManager.Lists.AddOrUpdateAsync(GetMailChimpList(ListName)).ConfigureAwait(false);        
+        }
+
+        private async Task<Store> ClearAndGetNewStore(string listId)
+        {
+            var stores = await this.MailChimpManager.ECommerceStores.GetAllAsync();
+            await Task.WhenAll(stores.Select(x => this.MailChimpManager.ECommerceStores.DeleteAsync(x.Id)));
+            var storeToCreate = new Store
+            {
+                Id = StoreName,
+                ListId = listId,
+                CurrencyCode = Currency,
+                Name = StoreName
+            };
+
+            return await this.MailChimpManager.ECommerceStores.AddAsync(storeToCreate);
+        }
+
+        private async Task<Customer> AddCustomerToStore(string storeId)
+        {
+            var customer = new Customer
+            {
+                Id = "1",
+                EmailAddress = "test@test.com",
+                OptInStatus = false
+            };
+
+            return await this.MailChimpManager.ECommerceStores.Customers(storeId).AddAsync(customer).ConfigureAwait(false);
+        }
+
+        private Product GetTestProduct()
+        {
+            return new Product
+            {
+                Id = "1",
+                Title = "Test",
+                Variants = new List<Variant>
+                {
+                    new Variant
+                    {
+                        Id="1",
+                        Title ="Test",
+                        Sku="1",
+                        Price=TestProductPrice
+                    }
+                }
+            };
         }
     }
 }


### PR DESCRIPTION
Fix the existing test.  The test was passing only because of the try catch.  In reality it should have been failing because an exception was being throw and the assert was never being reached.  The reason for failure being that not all the required field for a cart were being provider.  The relevant docs are here https://mailchimp.com/developer/reference/ecommerce-stores/ecommerce-carts/ and these state that required fields are id, customer, currency_code, order_total and lines.  The name of the test however is slightly confusing and maybe the original intent was for something else to be tested.  If this is the case let me know and I will attempt to cover this.  

Additionally created 2 further tests creating and updating products.

In the code for testing purposes I have used the customer email test@test.com, the same as can be found in MailChimpTest.cs. This is a problem however, see https://stackoverflow.com/questions/54883117/problem-with-synching-customers-with-mailchimp-through-api-v-3-customer-was-not.  I believe mailchimp has blacklisted this email and is not accepting it.  If you suggest a possible solution for this I will be happy to code it in.  I tried the tests with my own email address and all 3 pass.