### PR TITLE
Change the product update to work in a single patch request

### DIFF
--- a/MailChimp.Net/Logic/ECommerceProductLogic.cs
+++ b/MailChimp.Net/Logic/ECommerceProductLogic.cs
@@ -132,9 +132,15 @@ namespace MailChimp.Net.Logic
         /// </returns>
         public async Task<Product> UpdateAsync(string productId, Product product)
         {
-            //We need to delete and then readd in order to update...
-            await DeleteAsync(productId).ConfigureAwait(false);
-            return await AddAsync(product).ConfigureAwait(false);
+            var requestUrl = $"{string.Format(BaseUrl, StoreId)}/{productId}";
+
+            using (var client = CreateMailClient(requestUrl))
+            {
+                var response = await client.PatchAsJsonAsync("", product).ConfigureAwait(false);
+                await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
+                var productResponse = await response.Content.ReadAsAsync<Product>().ConfigureAwait(false);
+                return productResponse;
+            }
         }
 
         public string StoreId { get; set; }


### PR DESCRIPTION
Change product update logic to use a single patch request instead of 2 requests (delete followed by post).  See here for mail chimp docs https://mailchimp.com/developer/reference/ecommerce-stores/ecommerce-products/ and go to the edit tab.

Note there is a test for this logic in my pull request #461.

