### PR TITLE
Change BaseLogic.CreateMailClient method to return an httpclientwrapper

### DIFF
--- a/MailChimp.Net.Tests/MailChimp.Net.Tests.csproj
+++ b/MailChimp.Net.Tests/MailChimp.Net.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+    <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 

--- a/MailChimp.Net/Core/MailChimpHttpClient.cs
+++ b/MailChimp.Net/Core/MailChimpHttpClient.cs
@@ -1,0 +1,186 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CampaignStatus.cs" company="Brandon Seydel">
+//   N/A
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailChimp.Net.Core
+{
+    /// <summary>
+    /// Wrapper around HttpClient.  
+    /// </summary>
+    public class MailChimpHttpClient : IDisposable
+    {
+        private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings()
+        {
+            NullValueHandling = NullValueHandling.Ignore
+        };
+
+        private readonly MailChimpOptions _options;
+        private readonly HttpClient _httpClient;
+        private readonly string _resource;
+
+        public MailChimpHttpClient(HttpClient httpClient, MailChimpOptions options, string resource)
+        {
+            _httpClient = httpClient;
+            _options = options;
+
+            if(resource != null && resource.StartsWith("/"))
+            {
+                resource = resource.Substring(1);
+            }
+
+            _resource = resource;
+        }
+
+        public void Dispose()
+        {            
+#if !HTTP_CLIENT_FACTORY
+            _httpClient.Dispose();
+#endif
+        }
+
+        /// <summary>
+        /// Delete request
+        /// </summary> 
+        /// <param name="requestUri">
+        /// The request uri.
+        /// </param>     
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        public Task<HttpResponseMessage> DeleteAsync(string requestUri)
+        {
+            return SendAsync(HttpMethod.Delete, requestUri, contentOrNull: null);
+        }
+
+        /// <summary>
+        /// Get request
+        /// </summary> 
+        /// <param name="requestUri">
+        /// The request uri.
+        /// </param>     
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        public Task<HttpResponseMessage> GetAsync(string requestUri)
+        {
+            return SendAsync(HttpMethod.Get, requestUri, contentOrNull: null);
+        }
+
+        /// <summary>
+        /// Post request
+        /// </summary> 
+        /// <param name="requestUri">
+        /// The request uri.
+        /// </param>   
+        /// <param name="httpContent">
+        /// The httpContent
+        /// </param> 
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent httpContent)
+        {
+            return SendAsync(HttpMethod.Post, requestUri, contentOrNull: httpContent);
+        }
+
+        /// <summary>
+        /// The put as json async.
+        /// </summary> 
+        /// <param name="requestUri">
+        /// The request uri.
+        /// </param>
+        /// <param name="value">
+        /// The value.
+        /// </param>
+        /// <param name="settings"></param>
+        /// <typeparam name="T">
+        /// </typeparam>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        public Task<HttpResponseMessage> PutAsJsonAsync<T>(
+
+            string requestUri,
+            T value,
+            JsonSerializerSettings settings = null)
+        {
+            return SendAsync(HttpMethod.Put, requestUri, GetStringContent(value, settings));
+        }
+
+        /// <summary>
+        /// The patch as json async.
+        /// </summary>  
+        /// <param name="requestUri">
+        /// The request uri.
+        /// </param>
+        /// <param name="value">
+        /// The value.
+        /// </param>
+        /// <param name="settings"></param>
+        /// <typeparam name="T">
+        /// </typeparam>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        public Task<HttpResponseMessage> PatchAsJsonAsync<T>(
+
+            string requestUri,
+            T value,
+            JsonSerializerSettings settings = null)
+        {
+            return SendAsync(new HttpMethod("PATCH"), requestUri, GetStringContent(value, settings));
+        }
+        /// <summary>
+        /// PostAsJsonAsync
+        /// </summary>     
+        /// <param name="requestUri">
+        /// The request uri.
+        /// </param>
+        /// <param name="value">
+        /// The value.
+        /// </param>
+        /// <typeparam name="T">
+        /// </typeparam>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        public Task<HttpResponseMessage> PostAsJsonAsync<T>(
+            string requestUri,
+            T value,
+            JsonSerializerSettings settings = null)
+        {
+            return SendAsync(HttpMethod.Post, requestUri, GetStringContent(value, settings));
+        }
+
+        private StringContent GetStringContent<T>(T value, JsonSerializerSettings settings)
+        {
+            return new StringContent(JsonConvert.SerializeObject(value, settings ?? JsonSettings),
+                Encoding.UTF8,
+                "application/json");
+        }
+
+        private Task<HttpResponseMessage> SendAsync(HttpMethod method, string requestUri, HttpContent contentOrNull)
+        {
+            var request = new HttpRequestMessage(method,_resource + requestUri);
+            if (method.Method == "PATCH")
+            {
+                request.Headers.ExpectContinue = true;
+            }
+            request.Headers.Add("Authorization", _options.AuthHeader);
+            if (contentOrNull != null)
+            {
+                request.Content = contentOrNull;
+            }
+            return _httpClient.SendAsync(request);
+        }
+
+    }
+}

--- a/MailChimp.Net/MailChimp.Net.csproj
+++ b/MailChimp.Net/MailChimp.Net.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>
-      net45;netstandard1.3
+        net45;net472;netstandard1.3;netstandard2.0
     </TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -49,6 +49,7 @@
     <PackageTags>MailChimp Mail Chimp 3.0 v3.0 MailChimp.Net.V3 MailChimpv3.0 MailChimpv3 MailChimp3</PackageTags>
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
 
   </PropertyGroup>
   <ItemGroup>
@@ -59,9 +60,15 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="1.1.2" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.3'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.3' And '$(TargetFramework)' != 'netstandard2.0'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">
+        <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    </ItemGroup>   
   <ItemGroup>
     <None Include="..\LICENSE.txt">
       <Pack>True</Pack>
@@ -71,8 +78,12 @@
 
 
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard1.4' Or '$(TargetFramework)' == 'netstandard1.5' Or '$(TargetFramework)' == 'netstandard1.7' Or '$(TargetFramework)' == 'netstandard1.8' Or '$(TargetFramework)' == 'netstandard1.9' Or '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netcoreapp1.0' Or '$(TargetFramework)' == 'netcoreapp1.1' Or '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp2.2'">
-    <DefineConstants>NET_CORE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard1.4' Or '$(TargetFramework)' == 'netstandard1.5' Or '$(TargetFramework)' == 'netstandard1.7' Or '$(TargetFramework)' == 'netstandard1.8' Or '$(TargetFramework)' == 'netstandard1.9' Or '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netcoreapp1.0' Or '$(TargetFramework)' == 'netcoreapp1.1' Or '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp2.2'">
+        <DefineConstants>NET_CORE</DefineConstants>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp2.2' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net48' ">
+        <DefineConstants>HTTP_CLIENT_FACTORY</DefineConstants>
+    </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This pull request is in response to https://github.com/brandonseydel/MailChimp.Net/issues/323.  I.e. Convert to one HttpClient per resource.  The issue with disposing HttpClient is that the connection remains open for something like 100 seconds.  This means that there is a risk of socket exhaustion.  Using a single instance is also problematic.  The HttpClient holds onto the ip address it got when it first looked up the hostname and therefore does not know if this has changed.  Microsoft now recommends the use of HttpClientFactory which pools HttpClient instances.  The problem is that the library currently targets .net 4.5 and .net standard 1.3, neither of which support HttpClientFactory. To avoid breaking changes I have added .net framework 4.7.2 and .net standard 2.0 as targets.  This means platforms that support .net standard 2 and above will get the benefit of HttpClientFactory and if not the code will work as it did before, i.e. newed up HttpClients as and when they are needed.

The approach used is that suggested by janhansen in the comments https://github.com/brandonseydel/MailChimp.Net/issues/323 .  I.e. writing an httpclient wrapper that is returned by CreateMailClient.  This seemed the most sensible approach to me but if you think there is a better way let me know and I am happy to work on that alternative way.

I have run the unit tests and they have the same outcomes as they did before this update.  I have also done some basic tests on  .net framework 4.5, .net framework 4.7.2 and .net core 1.

This update has introduced a code analysis problem which you see when compiling in debug.  When RunCodeAnalysis is set to false in the csproj the problem goes away.  I believe that for .netstandard 2 a nuget package is needed (Microsoft.CodeAnalysis.FxCopAnalyzers). See https://github.com/dotnet/core/issues/758. 
