### PR TITLE
Code to clear a static segment with a single HTTP PATCH.

### DIFF
--- a/MailChimp.Net/Interfaces/IListSegmentLogic.cs
+++ b/MailChimp.Net/Interfaces/IListSegmentLogic.cs
@@ -13,7 +13,7 @@ namespace MailChimp.Net.Interfaces
         Task<ListSegmentResponse> GetResponseAsync(string listId, ListSegmentRequest request = null);
         Task<ListSegment> UpdateAsync(string listId, string segmentId, Segment segment);
         Task<Member> AddMemberAsync(string listId, string segmentId, Member member);
-        Task<ListSegment> ClearMembers(string listId, string segmentId);
+        Task<ListSegment> ClearMembersAsync(string listId, string segmentId);
         Task DeleteMemberAsync(string listId, string segmentId, string emailAddressOrHash);
         Task<MemberResponse> GetMemberResponseAsync(string listId, string segmentId, QueryableBaseRequest request = null);
         Task<IEnumerable<Member>> GetAllMembersAsync(string listId, string segmentId, QueryableBaseRequest request = null);

--- a/MailChimp.Net/Interfaces/IListSegmentLogic.cs
+++ b/MailChimp.Net/Interfaces/IListSegmentLogic.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using MailChimp.Net.Core;
 using MailChimp.Net.Models;
@@ -13,6 +13,7 @@ namespace MailChimp.Net.Interfaces
         Task<ListSegmentResponse> GetResponseAsync(string listId, ListSegmentRequest request = null);
         Task<ListSegment> UpdateAsync(string listId, string segmentId, Segment segment);
         Task<Member> AddMemberAsync(string listId, string segmentId, Member member);
+        Task<ListSegment> ClearMembers(string listId, string segmentId);
         Task DeleteMemberAsync(string listId, string segmentId, string emailAddressOrHash);
         Task<MemberResponse> GetMemberResponseAsync(string listId, string segmentId, QueryableBaseRequest request = null);
         Task<IEnumerable<Member>> GetAllMembersAsync(string listId, string segmentId, QueryableBaseRequest request = null);

--- a/MailChimp.Net/Logic/ListSegmentLogic.cs
+++ b/MailChimp.Net/Logic/ListSegmentLogic.cs
@@ -98,7 +98,7 @@ namespace MailChimp.Net.Logic
             }
         }
 
-        public async Task<ListSegment> ClearMembers(string listId, string segmentId)
+        public async Task<ListSegment> ClearMembersAsync(string listId, string segmentId)
         {
             using (var client = CreateMailClient(string.Format(BaseUrl + "/", listId)))
             {

--- a/MailChimp.Net/Logic/ListSegmentLogic.cs
+++ b/MailChimp.Net/Logic/ListSegmentLogic.cs
@@ -1,7 +1,6 @@
 using MailChimp.Net.Core;
 using MailChimp.Net.Interfaces;
 using MailChimp.Net.Models;
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/MailChimp.Net/Logic/ListSegmentLogic.cs
+++ b/MailChimp.Net/Logic/ListSegmentLogic.cs
@@ -1,6 +1,7 @@
 using MailChimp.Net.Core;
 using MailChimp.Net.Interfaces;
 using MailChimp.Net.Models;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -95,6 +96,19 @@ namespace MailChimp.Net.Logic
 
                 var memberResponse = await response.Content.ReadAsAsync<BatchSegmentMembersResponse>().ConfigureAwait(false);
                 return memberResponse;
+            }
+        }
+
+        public async Task<ListSegment> ClearMembers(string listId, string segmentId)
+        {
+            using (var client = CreateMailClient(string.Format(BaseUrl + "/", listId)))
+            {
+                var request = new { static_segment = new object[] { } };
+                var response = await client.PatchAsJsonAsync(segmentId, request).ConfigureAwait(false);
+                await response.EnsureSuccessMailChimpAsync().ConfigureAwait(false);
+
+                var segmentResponse = await response.Content.ReadAsAsync<ListSegment>().ConfigureAwait(false);
+                return segmentResponse;
             }
         }
 


### PR DESCRIPTION
This is related to issue #485. At the moment this is untested code, simply because I can't get the solution to compile for some reason, but I've tested the API call in Postman and it works.

This adds a single member to ListSegmentLogic and IListSegmentLogic called ClearMembers. It will send a PATCH request to the API with an empty `static_segment`, which will remove all members.

Is there a trick to getting this to build on VS 2019, with the latest updates? I wonder if I'm missing an older SDK. There were no build instructions.

I'm open to naming on this. Clear, ClearAll, DeleteAll, etc.