### PR TITLE
Increase verbosity of the Not Found error to include Instance

### DIFF
--- a/MailChimp.Net/Core/Helper.cs
+++ b/MailChimp.Net/Core/Helper.cs
@@ -36,14 +36,15 @@ namespace MailChimp.Net.Core
         {
             if (!response.IsSuccessStatusCode)
             {
+                var responseContentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                var error = responseContentStream.Deserialize<MailChimpApiError>();
+
                 if (response.StatusCode == HttpStatusCode.NotFound)
                 {
-                    throw new MailChimpNotFoundException($"Unable to find the resource at {response.RequestMessage.RequestUri} ");
+                    throw new MailChimpNotFoundException($"Unable to find the resource at {response.RequestMessage.RequestUri}", error, response);
                 }
 
-                var responseContentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-
-                throw new MailChimpException(responseContentStream.Deserialize<MailChimpApiError>(), response);
+                throw new MailChimpException(error, response);
             }
         }
 

--- a/MailChimp.Net/Core/MailChimpException.cs
+++ b/MailChimp.Net/Core/MailChimpException.cs
@@ -19,7 +19,8 @@ namespace MailChimp.Net.Core
     /// </summary>
     public class MailChimpException : Exception
     {
-        public MailChimpException(MailChimpApiError apierror, HttpResponseMessage rawHttpResponseMessage = null) : base(formatMessage(apierror))
+        public MailChimpException(string prefix, MailChimpApiError apierror, HttpResponseMessage rawHttpResponseMessage = null) 
+            : base((prefix != null ? $"{prefix} " : "")  +  formatMessage(apierror, rawHttpResponseMessage))
         {
             Detail = apierror.Detail;
             Title = apierror.Title;
@@ -30,15 +31,21 @@ namespace MailChimp.Net.Core
 
             RawHttpResponseMessage = rawHttpResponseMessage;
         }
+        public MailChimpException(MailChimpApiError apierror, HttpResponseMessage rawHttpResponseMessage = null) : this(null, apierror, rawHttpResponseMessage)
+        {
+        }
 
-        private static string formatMessage(MailChimpApiError apierror)
+        private static string formatMessage(MailChimpApiError apierror, HttpResponseMessage rawHttpResponseMessage)
         {
             StringBuilder builder = new StringBuilder();
             builder.AppendLine($"Title: {apierror.Title}");
             builder.AppendLine($"Type: {apierror.Type}");
             builder.AppendLine($"Status: {apierror.Status}");
+            builder.AppendLine($"Instance: {apierror.Instance}");
             builder.AppendLine($"Detail: {apierror.Detail}");
             builder.AppendLine("Errors: " + string.Join(" : ", apierror.Errors.Select(x => x.Field + " " + x.Message)));
+            if (rawHttpResponseMessage != null) 
+                builder.AppendLine("Request URI:" + rawHttpResponseMessage.RequestMessage.RequestUri);
             return builder.ToString();
         }
 

--- a/MailChimp.Net/Core/MailChimpNotFoundException.cs
+++ b/MailChimp.Net/Core/MailChimpNotFoundException.cs
@@ -1,10 +1,14 @@
-﻿using System;
+using System;
+using System.Net.Http;
+using MailChimp.Net.Models;
 
 namespace MailChimp.Net.Core
 {
-    public class MailChimpNotFoundException : Exception
+    public class MailChimpNotFoundException : MailChimpException
     {
-        public MailChimpNotFoundException(string message) : base(message)
+
+
+        public MailChimpNotFoundException(string message, MailChimpApiError error, HttpResponseMessage response) : base(message,error,response)
         {
         }
     }


### PR DESCRIPTION
I've had an issue where the MailChimp API is returning a NotFound error, for a list that most definitely exists. It occurs during a bulk action. The general exception code in `EnsureSuccessMailChimpAsync` actually handles their response body well, but it is discarded along with the useful `Instance` property. In the original code it is impossible access this data, which the comment even advises to include in support requests

> Gets or sets a string that identifies this specific occurrence of the problem. Please provide this ID when contacting support.

This PR changes the exception handling to ensure this information appears in exception messages. I'm using this internally to assist with my own support requests.