### PR TITLE
Enum additions

### DIFF
--- a/MailChimp.Net/Core/CampaignType.cs
+++ b/MailChimp.Net/Core/CampaignType.cs
@@ -49,6 +49,12 @@ namespace MailChimp.Net.Core
         /// The automation.
         /// </summary>
         [Description("automation")]
-        Automation = 32
+        Automation = 32,
+
+        /// <summary>
+        /// The automation-email.
+        /// </summary>
+        [Description("automation-email")]
+        AutomationEmail = 64
     }
 }

--- a/MailChimp.Net/Models/AutomationStatus.cs
+++ b/MailChimp.Net/Models/AutomationStatus.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace MailChimp.Net.Models
 {
@@ -9,6 +9,8 @@ namespace MailChimp.Net.Models
         [Description("paused")]
         Paused,
         [Description("sending")]
-        Sending
+        Sending,
+        [Description("archived")]
+        Archived
     }
 }


### PR DESCRIPTION
This PR adds two missing enum values that can cause exceptions in the Newtonsoft code leading to a failure to GET the corresponding types.

- CampaignType - add "automation-email"

- AutomationStatus - add "archived"