### PR TITLE
Handle serialization error for Data

### DIFF
--- a/MailChimp.Net/Core/MailChimpException.cs
+++ b/MailChimp.Net/Core/MailChimpException.cs
@@ -45,7 +45,7 @@ namespace MailChimp.Net.Core
             builder.AppendLine($"Detail: {apierror.Detail}");
             builder.AppendLine("Errors: " + string.Join(" : ", apierror.Errors.Select(x => x.Field + " " + x.Message)));
             if (rawHttpResponseMessage != null) 
-                builder.AppendLine("Request URI:" + rawHttpResponseMessage.RequestMessage.RequestUri);
+                builder.AppendLine("Request URI:" + rawHttpResponseMessage.RequestMessage?.RequestUri);
             return builder.ToString();
         }
 
@@ -97,7 +97,9 @@ namespace MailChimp.Net.Core
                 data.Add("status", Status);
                 data.Add("instance", Instance);
                 data.Add("errors", Errors);
+#if NET_CORE || NETSTANDARD
                 data.Add("rawhttpresponsemessage", RawHttpResponseMessage);
+#endif
 
                 _data = data;
                 return _data;


### PR DESCRIPTION
The on .NET (full framework) `RawHttpResponseMessage` is not serializable, and there appears to be a check on the Data dictionary that the object be serializable.

An exception would be thrown
```
 Message: 
    System.ArgumentException : Argument passed in is not serializable.
    Parameter name: value
```

I was initially extremely confused how `Data` could be throwing because it was having duplicate keys; turns out when debugging the subsequent evaluation changes the exception here. I was able to reprodce this on the unit tests by setting the framework to net48 on the unit test project and running only the exception test. The other tests appear to be failing due to disabled API Key (which is fair enough). :-)
