### PR TITLE
Fixes deserialization of Report #544

### DIFF
--- a/MailChimp.Net.Tests/SerializationTests.cs
+++ b/MailChimp.Net.Tests/SerializationTests.cs
@@ -1,0 +1,54 @@
+using MailChimp.Net.Core;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace MailChimp.Net.Tests
+{
+    public class SerializationTests
+    {
+        /// <summary>
+        /// Enum serialzation uses Json attributes.
+        /// </summary>
+        [Fact]
+        public void EnumsShouldSerializeWithDescriptionAttributes()
+        {
+            var enumTest = new EnumTest { CampaignType = CampaignType.Plaintext };
+
+            string json = JsonConvert.SerializeObject(enumTest);
+
+            Assert.Contains("plaintext", json);
+        }
+
+        /// <summary>
+        /// Enum deserialzation uses Json attributes.
+        /// </summary>
+        [Fact]
+        public void EnumsShouldDeserializeWithDescriptionAttributes()
+        {
+            string json = "{ \"CampaignType\": \"plaintext\" }";
+
+            var enumTest = JsonConvert.DeserializeObject<EnumTest>(json);
+
+            Assert.Equal(CampaignType.Plaintext, enumTest.CampaignType);
+        }
+
+        /// <summary>
+        /// Enum deserialzation uses Json attributes with "-" in description.
+        /// </summary>
+        [Fact]
+        public void EnumsShouldDeserializeWithDescriptionAttributesWithHyphen()
+        {
+            string json = "{ \"CampaignType\": \"automation-email\" }";
+
+            var enumTest = JsonConvert.DeserializeObject<EnumTest>(json);
+
+            Assert.Equal(CampaignType.AutomationEmail, enumTest.CampaignType);
+        }
+
+        public class EnumTest
+        {
+            [JsonConverter(typeof(StringEnumDescriptionConverter))]
+            public CampaignType CampaignType { get; set; }
+        }
+    }
+}

--- a/MailChimp.Net/Core/StringEnumDescriptionConverter.cs
+++ b/MailChimp.Net/Core/StringEnumDescriptionConverter.cs
@@ -52,8 +52,6 @@ namespace MailChimp.Net.Core
         /// <returns>
         /// The <see cref="bool"/>.
         /// </returns>
-        /// <exception cref="NotImplementedException">
-        /// </exception>
         public override bool CanConvert(Type objectType)
         {
             return objectType.GetTypeInfo().IsEnum;

--- a/MailChimp.Net/Core/StringEnumDescriptionConverter.cs
+++ b/MailChimp.Net/Core/StringEnumDescriptionConverter.cs
@@ -19,9 +19,9 @@ namespace MailChimp.Net.Core
     public class StringEnumDescriptionConverter : JsonConverter
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="StringEnumDescriptionConverter"/> class. 
+        /// Initializes a new instance of the <see cref="StringEnumDescriptionConverter"/> class.
         /// Initializes a new instance of the <see cref="T:Newtonsoft.Json.Converters.StringEnumConverter"/> class.
-        /// 
+        ///
         /// </summary>
         public StringEnumDescriptionConverter()
         {
@@ -30,9 +30,9 @@ namespace MailChimp.Net.Core
 
         /// <summary>
         /// Gets or sets a value indicating whether integer values are allowed.
-        /// 
+        ///
         /// </summary>
-        /// 
+        ///
         /// <value>
         /// <c>true</c> if integers are allowed; otherwise, <c>false</c>.
         /// </value>
@@ -56,7 +56,7 @@ namespace MailChimp.Net.Core
         /// </exception>
         public override bool CanConvert(Type objectType)
         {
-            throw new NotImplementedException();
+            return objectType.GetTypeInfo().IsEnum;
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace MailChimp.Net.Core
             objectType = Nullable.GetUnderlyingType(objectType) ?? objectType;
             var eTypeVal = objectType
                         .GetRuntimeFields().Cast<MemberInfo>()
-                        .Union(objectType.GetRuntimeProperties())                        
+                        .Union(objectType.GetRuntimeProperties())
                         .Where(x => x.GetCustomAttributes(typeof(DescriptionAttribute)).Any())
                         .FirstOrDefault(x => ((DescriptionAttribute)x.GetCustomAttribute(typeof(DescriptionAttribute))).Description == (string)reader.Value);
 
@@ -91,7 +91,7 @@ namespace MailChimp.Net.Core
 
         /// <summary>
         /// Writes the JSON representation of the object.
-        /// 
+        ///
         /// </summary>
         /// <param name="writer">
         /// The <see cref="T:Newtonsoft.Json.JsonWriter"/> to write to.

--- a/MailChimp.Net/Models/Report.cs
+++ b/MailChimp.Net/Models/Report.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Report.cs" company="Brandon Seydel">
 //   N/A
 // </copyright>
@@ -129,8 +129,9 @@ namespace MailChimp.Net.Models
         /// Gets or sets the type.
         /// </summary>
         [JsonProperty("type")]
+        [JsonConverter(typeof(StringEnumDescriptionConverter))]
         public CampaignType Type { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the unsubscribed.
         /// </summary>


### PR DESCRIPTION
This is a fix for https://github.com/brandonseydel/MailChimp.Net/issues/544

I've applied the `StringEnumDescriptionConverter` to the `Report` model class's `CampaignType` property. Additionally, I've enabled the `StringEnumDescriptionConverter` to indicate it can both serialize and deserialize any enum if the converter is added globally.

Finally, I added a few basic serialization unit tests.