### PR TITLE
Missing properties added into the MemberRequest model

### DIFF
--- a/MailChimp.Net/Core/Requests/MemberRequest.cs
+++ b/MailChimp.Net/Core/Requests/MemberRequest.cs
@@ -59,5 +59,11 @@ namespace MailChimp.Net.Core
         /// </summary>
         [QueryString("sort_dir")]
         public MemberSortOrder? SortOrder { get; set; }
+
+        [QueryString("since_last_campaign")]
+        public bool SinceLastCampaign { get; set; }
+
+        [QueryString("unsubscribed_since")]
+        public string UnsubscribedSince { get; set; }
     }
 }


### PR DESCRIPTION
MailChimp member request api contains two more properties that were missing in the MemberRequest model. 

        [QueryString("since_last_campaign")]
        public bool SinceLastCampaign { get; set; }

        [QueryString("unsubscribed_since")]
        public string UnsubscribedSince { get; set; }

Ref: https://mailchimp.com/developer/marketing/api/list-members/list-members-info/  