### PR TITLE
Match HttpClient's timeout to API timeout

### DIFF
--- a/MailChimp.Net/Core/BaseLogic.cs
+++ b/MailChimp.Net/Core/BaseLogic.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
-#if HTTP_CLIENT_FACTORY 
+#if HTTP_CLIENT_FACTORY
 using Microsoft.Extensions.DependencyInjection;
 #endif
 
@@ -23,6 +23,8 @@ namespace MailChimp.Net.Core
     /// </summary>
     public abstract class BaseLogic
     {
+        internal const int ApiTimeout = 120;
+
         internal int _limit => _options.Limit;
 
         internal MailChimpOptions _options;
@@ -41,7 +43,8 @@ namespace MailChimp.Net.Core
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddHttpClient(this._options.ApiKey ?? "OAuthMode", client =>
             {
-                client.BaseAddress = new Uri(GetBaseAddress());               
+                client.BaseAddress = new Uri(GetBaseAddress());
+                client.Timeout = TimeSpan.FromSeconds(ApiTimeout);
             })
                 .ConfigurePrimaryHttpMessageHandler(handler =>
                 new HttpClientHandler()
@@ -80,7 +83,7 @@ namespace MailChimp.Net.Core
         protected MailChimpHttpClient CreateMailClient(string resource)
         {
 #if HTTP_CLIENT_FACTORY
-            return FactoryProvidedHttpClient(resource);            
+            return FactoryProvidedHttpClient(resource);
 #else
             return NewedUpHttpClient(resource);
 #endif
@@ -89,7 +92,7 @@ namespace MailChimp.Net.Core
 
 #if HTTP_CLIENT_FACTORY
         private MailChimpHttpClient FactoryProvidedHttpClient(string resource)
-        {           
+        {
             var client = GetHttpClientFactory().CreateClient(_options.ApiKey ?? "OAuthMode");
             return new MailChimpHttpClient(client, _options, resource);
         }
@@ -97,7 +100,7 @@ namespace MailChimp.Net.Core
 
 
         private MailChimpHttpClient NewedUpHttpClient(string resource)
-        {           
+        {
             var handler = new HttpClientHandler();
             if (handler.SupportsAutomaticDecompression)
             {
@@ -105,7 +108,8 @@ namespace MailChimp.Net.Core
             }
             var client = new HttpClient(handler)
             {
-                BaseAddress = new Uri(GetBaseAddress())
+                BaseAddress = new Uri(GetBaseAddress()),
+                Timeout = TimeSpan.FromSeconds(ApiTimeout)
             };
             return new MailChimpHttpClient(client, _options, resource);
         }
@@ -132,13 +136,13 @@ namespace MailChimp.Net.Core
         /// <paramref>
         ///         <name>s</name>
         ///     </paramref>
-        ///     is null. 
+        ///     is null.
         /// </exception>
         /// <exception cref="EncoderFallbackException">
         /// A fallback occurred (see Character Encoding in the .NET Framework for complete explanation)-and-<see cref="P:System.Text.Encoding.EncoderFallback"/> is set to <see cref="T:System.Text.EncoderExceptionFallback"/>.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
-        /// Enlarging the value of this instance would exceed <see cref="P:System.Text.StringBuilder.MaxCapacity"/>. 
+        /// Enlarging the value of this instance would exceed <see cref="P:System.Text.StringBuilder.MaxCapacity"/>.
         /// </exception>
         /// <exception cref="FormatException">
         /// <paramref>


### PR DESCRIPTION
Mailchimp's API timeout is 120 seconds. I increased the HttpClient's timeout from the default of 100 seconds to 120 seconds.

References:
- https://mailchimp.com/developer/marketing/docs/fundamentals/#api-limits
- https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.timeout