### PR TITLE
Bump Newtonsoft.Json from 12.0.3 to 13.0.1

### DIFF
--- a/MailChimp.Net/MailChimp.Net.csproj
+++ b/MailChimp.Net/MailChimp.Net.csproj
@@ -56,7 +56,7 @@
 
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">


### PR DESCRIPTION
According to [https://github.com/advisories/GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr)

Newtonsoft.Json prior to version 13.0.1 is vulnerable to Insecure Defaults due to improper handling of expressions with high nesting level that lead to StackOverFlow exception or high CPU and RAM usage. Exploiting this vulnerability results in Denial Of Service (DoS).