### PR TITLE
Exception data inserted by index to avoid duplicates

### DIFF
--- a/MailChimp.Net/Core/MailChimpException.cs
+++ b/MailChimp.Net/Core/MailChimpException.cs
@@ -91,14 +91,14 @@ namespace MailChimp.Net.Core
                     return _data;
 
                 var data = base.Data;
-                data.Add("detail", Detail);
-                data.Add("title", Title);
-                data.Add("type", Type);
-                data.Add("status", Status);
-                data.Add("instance", Instance);
-                data.Add("errors", Errors);
+                data["detail"] = Detail;
+                data["title"] = Title;
+                data["type"] = Type;
+                data["status"] = Status;
+                data["instance"] = Instance;
+                data["errors"] = Errors;
 #if NET_CORE || NETSTANDARD
-                data.Add("rawhttpresponsemessage", RawHttpResponseMessage);
+                data["rawhttpresponsemessage"] = RawHttpResponseMessage;
 #endif
 
                 _data = data;


### PR DESCRIPTION
We have observed that, if the parent `Exception` was created from a `SerializationInfo` object containing any of the current data values (detail, title, type, etc), there is a potential risk of getting an `ArgumentException` here.

With this fix, any existing data attribute in the current exception would be just overwritten, avoiding the exception.

Below you can see an actual exception being thrown by this issue in Microsoft's ApplicationInsights library.
```
System.ArgumentException: Item has already been added. Key in dictionary: 'detail'  Key being added: 'detail'
   at System.Collections.ListDictionaryInternal.Add(Object key, Object value)
   at MailChimp.Net.Core.MailChimpException.get_Data()
   at Microsoft.ApplicationInsights.SnapshotCollector.ExceptionExtensions.HasSnapshotContext(Exception ex)
   at Microsoft.ApplicationInsights.SnapshotCollector.ExceptionExtensions.GetSnapshotContext(Exception ex)
   at Microsoft.ApplicationInsights.SnapshotCollector.SnapshotCollectorTelemetryProcessor.ProcessExceptionTelemetry(ExceptionTelemetry exceptionTelemetry)
   at Microsoft.ApplicationInsights.SnapshotCollector.SnapshotCollectorTelemetryProcessor.Process(ITelemetry item)
   ...
```

Closes #593 