### PR TITLE
Switch to using PackageLicenseExpression

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -20,12 +20,8 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1.7.2
-        with:
-          dotnet-version: 3.1.x
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: dotnet restore
       - name: Build
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build --configuration Release --no-restore -p:ContinuousIntegrationBuild=True 

--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,5 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+
+.idea

--- a/MailChimp.Net/MailChimp.Net.csproj
+++ b/MailChimp.Net/MailChimp.Net.csproj
@@ -50,8 +50,7 @@
         </PackageReleaseNotes>
         <PackageIconUrl>http://logos-download.com/wp-content/uploads/2016/09/MailChimp_logo_icon_Freddie_Wink.png</PackageIconUrl>
         <PackageTags>MailChimp Mail Chimp 3.0 v3.0 MailChimp.Net.V3 MailChimpv3.0 MailChimpv3 MailChimp3</PackageTags>
-        <PackageLicenseUrl></PackageLicenseUrl>
-        <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RunAnalyzersDuringBuild>True</RunAnalyzersDuringBuild>
         <AssemblyVersion>5.5.0</AssemblyVersion>
         <FileVersion>5.5.0</FileVersion>


### PR DESCRIPTION
NuGet.org will then be able to show the correct license info and also automatic license checkers/validator will work properly. Also updates GH Actions workflow definition to do a deterministic build and cleaned up against the latest runners which don't need installations.