### PR TITLE
fix: Address property of mergefield is an object not a string

### DIFF
--- a/MailChimp.Net/Core/Responses/AddressResponse.cs
+++ b/MailChimp.Net/Core/Responses/AddressResponse.cs
@@ -1,0 +1,42 @@
+﻿using Newtonsoft.Json;
+
+namespace MailChimp.Net.Core.Responses;
+
+public class AddressResponse
+{
+    /// <summary>
+    /// Gets or sets the address 1.
+    /// </summary>
+    [JsonProperty("addr1")]
+    public string Address1 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the address 2.
+    /// </summary>
+    [JsonProperty("addr2")]
+    public string Address2 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the city.
+    /// </summary>
+    [JsonProperty("city")]
+    public string City { get; set; }
+
+    /// <summary>
+    /// Gets or sets the state.
+    /// </summary>
+    [JsonProperty("state")]
+    public string State { get; set; }
+
+    /// <summary>
+    /// Gets or sets the zip.
+    /// </summary>
+    [JsonProperty("zip")]
+    public string Zip { get; set; }
+
+    /// <summary>
+    /// Gets or sets the country.
+    /// </summary>
+    [JsonProperty("country")]
+    public string Country { get; set; }
+}

--- a/MailChimp.Net/Core/Responses/MergeFields.cs
+++ b/MailChimp.Net/Core/Responses/MergeFields.cs
@@ -11,7 +11,7 @@ public class MergeFields
     public string LastName { get; set; }
 
     [JsonProperty("ADDRESS")]
-    public string Address { get; set; }
+    public AddressResponse Address { get; set; }
 
     [JsonProperty("PHONE")]
     public string Phone { get; set; }

--- a/MailChimp.Net/MailChimp.Net.csproj
+++ b/MailChimp.Net/MailChimp.Net.csproj
@@ -32,7 +32,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <AssemblyOriginatorKeyFile>MailChimp.Key.snk</AssemblyOriginatorKeyFile>
         <PackageId>MailChimp.Net.V3</PackageId>
-        <Version>5.7.0</Version>
+        <Version>5.7.1</Version>
         <Authors>Brandon Seydel</Authors>
         <Company>DevSquad</Company>
         <Product>MailChimp.Net.V3</Product>
@@ -45,16 +45,15 @@
         <RepositoryType>Git</RepositoryType>
         <NeutralLanguage />
         <PackageReleaseNotes>
-            .NET Standard 1.3
-            .NETFramework 4.5
+            Address mergefield is an object instead of string
         </PackageReleaseNotes>
         <PackageIconUrl>http://logos-download.com/wp-content/uploads/2016/09/MailChimp_logo_icon_Freddie_Wink.png</PackageIconUrl>
         <PackageTags>MailChimp Mail Chimp 3.0 v3.0 MailChimp.Net.V3 MailChimpv3.0 MailChimpv3 MailChimp3</PackageTags>
         <PackageLicenseUrl></PackageLicenseUrl>
         <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
         <RunAnalyzersDuringBuild>True</RunAnalyzersDuringBuild>
-        <AssemblyVersion>5.7.0</AssemblyVersion>
-        <FileVersion>5.7.0</FileVersion>
+        <AssemblyVersion>5.7.1</AssemblyVersion>
+        <FileVersion>5.7.1</FileVersion>
         <EnableNETAnalyzers>True</EnableNETAnalyzers>
         <PackageIcon>icon.png</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
If there is an address in [MergeFields](https://github.com/brandonseydel/MailChimp.Net/compare/master...OrphisSoftware:MailChimp.Net:fix/mergefield-address-not-a-string?expand=1#diff-d5b14d94ecc3d5dbad05c5bbda8f0ab7e290bd1055eccd4b3b07d9436132484e) the deserialization fails. 